### PR TITLE
Upgrade install file to utilize drupal 8 schema and functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 composer.phar
 */vendor/

--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -1,0 +1,637 @@
+<?php
+/**
+ * @file
+ * Contains functions used to install/uninstall tripal.
+ */
+
+use \Drupal\Core\Database\Database;
+
+/**
+ * Implementation of hook_install().
+ *
+ * @ingroup tripal
+ */
+function tripal_install() {
+  // On upgrade from Tv2 to Tv3 we need to add a new field to the tripal_jobs
+  // table it's missing.
+  $schema = Database::getConnection()->schema();
+  if (!$schema->fieldExists('tripal_jobs', 'includes')) {
+    $schema->addField('tripal_jobs', 'includes', [
+      'type' => 'text',
+      'description' => "A serialized array of file paths that should be included prior to executing the job.",
+      'length' => 20,
+      'not null' => FALSE,
+    ]);
+  }
+
+  //$menu = [
+  //  'menu_name' => 'data_search',
+  //  'title' => t('Data Search'),
+  //  'description' => '',
+  //];
+  //menu_save($menu);
+
+  Drupal::entityTypeManager()->getStorage('menu')->create([
+    'id' => 'data_search',
+    'label' => t('Data Search'),
+    'description' => t('The Data Search menu contains links to search tools for finding biological data.'),
+  ])->save();
+}
+
+/**
+ * Adds variables for bundles.
+ */
+function tripal_add_variables() {
+  // Add tripal bundle variables needed for storing additional settings for
+  // Tripal Bundles.
+
+  // ---------------------------------------------------------
+  // - Commented out until we move to drupal 8 configuration -
+  // ---------------------------------------------------------
+
+  //tripal_insert_variable('title_format',
+  //  'A pattern including tokens that can be used to generate tripal entity titles.');
+  //tripal_insert_variable('url_format',
+  //  'A pattern including tokens that can be used to generate tripal entity url aliases.');
+  //tripal_insert_variable('description',
+  //  'The description of a Tripal Entity type/bundle.');
+  //tripal_insert_variable('hide_empty_field',
+  //  'Structure->Tripal Content Type->edit checkbox to hide empty fields for that bundle.');
+  //tripal_insert_variable('ajax_field',
+  //  'Structure->Tripal Content Type->edit checkbox for ajax fields for that bundle.');
+}
+
+/**
+ *
+ */
+function tripal_uninstall() {
+  /*
+   // So somehow I was able to uninstall this module without deleting the bundles. This
+   // caused aweful errors because fields weren't deleted so when I re-installed, the code
+   // tried to create fields that were inactive (despite checking if the field exists
+   // before creating). The following code was meant to ensure that all content was deleted
+   // before uninstall so these errors would not occur. Unfortunatly I am now unable to
+   // test this because the Field API module is disabling uninstall of Tripal Chado until
+   // all the content is deleted. Thus ensuring the errors described above don't occur.
+   // But I'm Sure I was able to uninstall with content before...
+   // **I am slowly going crazy; Crazy going slowly am I**
+   // Anyway, I'll leaving the solution code here in case I am able to repeat it in
+   // the future.
+   // @see https://www.drupal.org/node/1262092
+   // @see https://www.drupal.org/node/1861710
+
+   // First delete all TripalEntities.
+   $entity_ids = (new EntityFieldQuery)->entityCondition("entity_type", "TripalEntity")->execute();
+   $entity_ids = reset($entity_ids);
+   entity_delete_multiple("TripalEntity", array_keys($entity_ids));
+
+   // Then delete all TripalBundles.
+   $bundle_ids = (new EntityFieldQuery)->entityCondition("entity_type", "TripalBundle")->execute();
+   $bundle_ids = reset($bundle_ids);
+   entity_delete_multiple("TripalBundle", array_keys($bundle_ids));
+
+   // @TODO: Should we delete all TripalVocabularies and TripalTerms?
+
+   // Finally purge all fields that are no longer used.
+   field_purge_batch(100);
+   */
+}
+
+/**
+ *
+ */
+function tripal_enable() {
+  // If Tripal v2 is already installed, the installation of this module
+  // will try and recreate some of the tables created with tripal_core and the
+  // installation will fail.  Therefore, in the install we renamed it. Now
+  // we want to move it back.
+  if (db_table_exists('tripal_jobs2')) {
+    $sql = "DROP TABLE tripal_jobs";
+    db_query($sql);
+    db_rename_table('tripal_jobs2', 'tripal_jobs');
+  }
+
+  if (db_table_exists('tripal_token_formats2')) {
+    $sql = "DROP TABLE tripal_token_formats";
+    db_query($sql);
+    db_rename_table('tripal_token_formats2', 'tripal_token_formats');
+  }
+
+  if (db_table_exists('tripal_variables2')) {
+    $sql = "DROP TABLE tripal_variables";
+    db_query($sql);
+    db_rename_table('tripal_variables2', 'tripal_variables');
+  }
+
+  if (db_table_exists('tripal_custom_quota2')) {
+    $sql = "DROP TABLE tripal_custom_quota";
+    db_query($sql);
+    db_rename_table('tripal_custom_quota2', 'tripal_custom_quota');
+  }
+
+  if (db_table_exists('tripal_expiration_files2')) {
+    $sql = "DROP TABLE tripal_expiration_files";
+    db_query($sql);
+    db_rename_table('tripal_expiration_files2', 'tripal_expiration_files');
+  }
+
+  // schema change
+  if (!db_field_exists('tripal_jobs', 'includes')) {
+    $sql = "ALTER TABLE tripal_jobs ADD COLUMN includes text";
+    db_query($sql);
+  }
+
+  tripal_add_variables();
+}
+
+/**
+ * Implementation of hook_schema().
+ *
+ * @ingroup tripal
+ */
+function tripal_schema() {
+
+  // If Tripal v2 is already installed, the installation of this module
+  // will try and recreate some of the tables created with tripal_core and the
+  // installation will fail.  Therefore, we need to temporarily move those
+  // tables out of the way, let the module install and then move them back.
+
+  $schema = [];
+
+  $schema['tripal_jobs'] = tripal_tripal_jobs_schema();
+  $schema['tripal_token_formats'] = tripal_tripal_token_formats_schema();
+  $schema['tripal_variables'] = tripal_tripal_variables_schema();
+  $schema['tripal_expiration_files'] = tripal_tripal_expiration_files_schema();
+  $schema['tripal_custom_quota'] = tripal_tripal_custom_quota_schema();
+
+  $schema['tripal_import'] = tripal_tripal_import_schema();
+  $schema['tripal_collection'] = tripal_tripal_collection_schema();
+  $schema['tripal_collection_bundle'] = tripal_tripal_collection_bundle_schema();
+
+  // Adds a table for administrative notifications on the dashboard.
+  $schema['tripal_admin_notfications'] = tripal_tripal_admin_notifications_schema();
+  return $schema;
+}
+
+/**
+ * Returns the Drupal Schema API array for the tripal_jobs table.
+ */
+function tripal_tripal_jobs_schema() {
+  return [
+    'fields' => [
+      'job_id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'uid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'The Drupal userid of the submitee',
+      ],
+      'job_name' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'modulename' => [
+        'type' => 'varchar',
+        'length' => 50,
+        'not null' => TRUE,
+        'description' => 'The module name that provides the callback for this job',
+      ],
+      'callback' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'arguments' => [
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => FALSE,
+      ],
+      'progress' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'default' => 0,
+        'not null' => FALSE,
+        'description' => 'a value from 0 to 100 indicating percent complete',
+      ],
+      'status' => [
+        'type' => 'varchar',
+        'length' => 50,
+        'not null' => TRUE,
+      ],
+      'submit_date' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'description' => 'UNIX integer submit time',
+      ],
+      'start_time' => [
+        'type' => 'int',
+        'not null' => FALSE,
+        'description' => 'UNIX integer start time',
+      ],
+      'end_time' => [
+        'type' => 'int',
+        'not null' => FALSE,
+        'description' => 'UNIX integer end time',
+      ],
+      'error_msg' => [
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => FALSE,
+      ],
+      'pid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'description' => 'The process id for the job',
+      ],
+      'priority' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => '0',
+        'description' => 'The job priority',
+      ],
+      'mlock' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'description' => 'If set to 1 then all jobs for the module are held until this one finishes',
+      ],
+      'lock' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => FALSE,
+        'description' => 'If set to 1 then all jobs are held until this one finishes',
+      ],
+      'includes' => [
+        'type' => 'text',
+        'description' => 'A serialized array of file paths that should be included prior to executing the job.',
+        'not null' => FALSE,
+      ],
+    ],
+    'indexes' => [
+      'job_id' => ['job_id'],
+      'job_name' => ['job_name'],
+    ],
+    'primary key' => ['job_id'],
+  ];
+}
+
+/**
+ * Returns the Drupal Schema API array for the tripal_jobs table.
+ */
+function tripal_tripal_collection_schema() {
+  return [
+    'fields' => [
+      'collection_id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'collection_name' => [
+        'type' => 'varchar',
+        'length' => 1024,
+        'not null' => TRUE,
+      ],
+      'description' => [
+        'type' => 'text',
+        'not null' => FALSE,
+      ],
+      'uid' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'description' => 'The user Id of the person who created the collection.',
+      ],
+      'create_date' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'description' => 'UNIX integer start time',
+      ],
+    ],
+    'indexes' => [
+      'uid' => ['uid'],
+    ],
+    'unique keys' => [
+      'user_collection' => ['uid', 'collection_name'],
+    ],
+    'primary key' => ['collection_id'],
+  ];
+}
+
+/**
+ * Returns the Drupal Schema API array for the tripal_jobs table.
+ */
+function tripal_tripal_collection_bundle_schema() {
+  return [
+    'fields' => [
+      'collection_bundle_id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'collection_id' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'bundle_name' => [
+        'type' => 'varchar',
+        'length' => 1024,
+        'not null' => TRUE,
+      ],
+      'ids' => [
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => TRUE,
+        'description' => 'An array of entity IDs.',
+      ],
+      'fields' => [
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => TRUE,
+        'description' => 'An array of numeric field IDs.',
+      ],
+      'site_id' => [
+        'type' => 'int',
+        'size' => 'normal',
+        'not null' => FALSE,
+        'description' => 'The ID of the site from the Tripal Sites table.',
+      ],
+    ],
+    'indexes' => [
+      'collection_id' => ['collection_id'],
+    ],
+    'primary key' => ['collection_bundle_id'],
+  ];
+}
+
+/**
+ * Returns the Drupal Schema API array for the tripal_jobs table.
+ */
+function tripal_tripal_import_schema() {
+  return [
+    'fields' => [
+      'import_id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'uid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'The Drupal userid of the submitee.',
+      ],
+      'class' => [
+        'type' => 'varchar',
+        'length' => 256,
+        'not null' => TRUE,
+      ],
+      'fid' => [
+        'type' => 'text',
+        'not null' => FALSE,
+        'description' => 'The file IDs of the to import. This only applies if the file was uploaded (i.e. not already on the server) and is mangaged by Drupal. Multiple fids are separated using a | character.',
+      ],
+      'arguments' => [
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => FALSE,
+        'description' => 'Holds a serialized PHP array containing the key/value paris that are used for arguments of the job.',
+      ],
+      'submit_date' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'description' => 'UNIX integer submit time',
+      ],
+    ],
+    'indexes' => [
+      'class' => ['class'],
+    ],
+    'foreign keys' => [
+      'tripal_jobs' => [
+        'table' => 'tripal_jobs',
+        'columns' => [
+          'job_id' => 'job_id',
+        ],
+      ],
+      'users' => [
+        'table' => 'users',
+        'columns' => [
+          'uid' => 'uid',
+        ],
+      ],
+      'file_managed' => [
+        'table' => 'file_managed',
+        'columns' => [
+          'fid' => 'fid',
+        ],
+      ],
+    ],
+    'primary key' => ['import_id'],
+  ];
+}
+
+/**
+ *
+ * @return
+ */
+function tripal_tripal_token_formats_schema() {
+  return [
+    'fields' => [
+      'tripal_format_id' => [
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'content_type' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'application' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'format' => [
+        'type' => 'text',
+        'not null' => TRUE,
+      ],
+      'tokens' => [
+        'type' => 'text',
+        'not null' => TRUE,
+      ],
+    ],
+    'unique keys' => [
+      'type_application' => ['content_type', 'application'],
+    ],
+    'primary key' => ['tripal_format_id'],
+  ];
+}
+
+function tripal_tripal_variables_schema() {
+
+  return [
+    'description' => 'This table houses a list of unique variable names that ' . 'can be used in the tripal_node_variables table.',
+    'fields' => [
+      'variable_id' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+      ],
+      'name' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'description' => [
+        'type' => 'text',
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => [
+      0 => 'variable_id',
+    ],
+    'unique keys' => [
+      'tripal_variables_c1' => [
+        0 => 'name',
+      ],
+    ],
+    'indexes' => [
+      'tripal_variable_names_idx1' => [
+        0 => 'variable_id',
+      ],
+    ],
+  ];
+
+  return $schema;
+}
+
+/**
+ * @section
+ * Schema Definitions.
+ */
+
+/**
+ * Provides the schema for the tripal_custom_quota table.
+ */
+function tripal_tripal_custom_quota_schema() {
+  $schema = [
+    'table' => 'tripal_custom_quota',
+    'fields' => [
+      'uid' => [
+        'type' => 'int',
+        'size' => 'big',
+        'not null' => TRUE,
+      ],
+      'custom_quota' => [
+        'type' => 'int',
+        'size' => 'big',
+        'not null' => TRUE,
+      ],
+      'custom_expiration' => [
+        'type' => 'int',
+        'size' => 'big',
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => ['uid'],
+    'unique keys' => [
+      'tripal_custom_quota_uq1' => ['uid'],
+    ],
+    'indexes' => [
+      'tripal_custom_quota_idx1' => ['uid'],
+    ],
+  ];
+  return $schema;
+}
+
+/**
+ * Provides the schema for the tripal_expiration_files table.
+ */
+function tripal_tripal_expiration_files_schema() {
+  $schema = [
+    'table' => 'tripal_expiration_files',
+    'fields' => [
+      'fid' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'expiration_date' => [
+        'type' => 'int',
+        'size' => 'big',
+        'not null' => TRUE,
+      ],
+    ],
+    'primary key' => [
+      0 => 'fid',
+    ],
+    'unique keys' => [
+      'tripal_expiration_files_uq1' => ['fid'],
+    ],
+    'indexes' => [
+      'tripal_expiration_files_idx1' => ['fid'],
+    ],
+  ];
+  return $schema;
+}
+
+/**
+ * Additional Tripal Admin Notification Information.
+ *
+ * This table is used for information describing administrative
+ * notifications. For example, when new fields are available.
+ */
+function tripal_tripal_admin_notifications_schema() {
+
+  $schema = [
+    'description' => 'This table is used for information describing administrative
+     notifications. For example, when new fields are available.',
+    'fields' => [
+      'note_id' => [
+        'type' => 'serial',
+        'not null' => TRUE,
+      ],
+      'details' => [
+        'description' => 'Description and additional information relating to the notification.',
+        'type' => 'text',
+        'not null' => TRUE,
+      ],
+      'title' => [
+        'description' => 'Title of the notification.',
+        'type' => 'text',
+        'not null' => TRUE,
+      ],
+      'actions' => [
+        'description' => 'Actions that can be performed on the notification, like disimissal or import.',
+        'type' => 'text',
+        'not null' => FALSE,
+      ],
+      'submitter_id' => [
+        'description' => 'A unique id that should be specific to the notification to ensure notifications are not duplicated.',
+        'type' => 'text',
+        'not null' => TRUE,
+      ],
+      'enabled' => [
+        'description' => 'Boolean indicating whether the notification is enabled or disabled (disabled will not be shown on the dashboard).',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 1,
+      ],
+      'type' => [
+        'description' => 'Type of the notification, relating to what tripal function the notification belongs to, IE Fields, Jobs, Vocabulary.',
+        'type' => 'text',
+        'not null' => FALSE,
+      ],
+    ],
+    'primary key' => [
+      0 => 'note_id',
+    ],
+  ];
+
+  return $schema;
+}

--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -97,52 +97,52 @@ function tripal_uninstall() {
    */
 }
 
-/**
- *
- */
-function tripal_enable() {
-  // If Tripal v2 is already installed, the installation of this module
-  // will try and recreate some of the tables created with tripal_core and the
-  // installation will fail.  Therefore, in the install we renamed it. Now
-  // we want to move it back.
-  if (db_table_exists('tripal_jobs2')) {
-    $sql = "DROP TABLE tripal_jobs";
-    db_query($sql);
-    db_rename_table('tripal_jobs2', 'tripal_jobs');
-  }
-
-  if (db_table_exists('tripal_token_formats2')) {
-    $sql = "DROP TABLE tripal_token_formats";
-    db_query($sql);
-    db_rename_table('tripal_token_formats2', 'tripal_token_formats');
-  }
-
-  if (db_table_exists('tripal_variables2')) {
-    $sql = "DROP TABLE tripal_variables";
-    db_query($sql);
-    db_rename_table('tripal_variables2', 'tripal_variables');
-  }
-
-  if (db_table_exists('tripal_custom_quota2')) {
-    $sql = "DROP TABLE tripal_custom_quota";
-    db_query($sql);
-    db_rename_table('tripal_custom_quota2', 'tripal_custom_quota');
-  }
-
-  if (db_table_exists('tripal_expiration_files2')) {
-    $sql = "DROP TABLE tripal_expiration_files";
-    db_query($sql);
-    db_rename_table('tripal_expiration_files2', 'tripal_expiration_files');
-  }
-
-  // schema change
-  if (!db_field_exists('tripal_jobs', 'includes')) {
-    $sql = "ALTER TABLE tripal_jobs ADD COLUMN includes text";
-    db_query($sql);
-  }
-
-  tripal_add_variables();
-}
+///**
+// *
+// */
+//function tripal_enable() {
+//  // If Tripal v2 is already installed, the installation of this module
+//  // will try and recreate some of the tables created with tripal_core and the
+//  // installation will fail.  Therefore, in the install we renamed it. Now
+//  // we want to move it back.
+//  if (db_table_exists('tripal_jobs2')) {
+//    $sql = "DROP TABLE tripal_jobs";
+//    db_query($sql);
+//    db_rename_table('tripal_jobs2', 'tripal_jobs');
+//  }
+//
+//  if (db_table_exists('tripal_token_formats2')) {
+//    $sql = "DROP TABLE tripal_token_formats";
+//    db_query($sql);
+//    db_rename_table('tripal_token_formats2', 'tripal_token_formats');
+//  }
+//
+//  if (db_table_exists('tripal_variables2')) {
+//    $sql = "DROP TABLE tripal_variables";
+//    db_query($sql);
+//    db_rename_table('tripal_variables2', 'tripal_variables');
+//  }
+//
+//  if (db_table_exists('tripal_custom_quota2')) {
+//    $sql = "DROP TABLE tripal_custom_quota";
+//    db_query($sql);
+//    db_rename_table('tripal_custom_quota2', 'tripal_custom_quota');
+//  }
+//
+//  if (db_table_exists('tripal_expiration_files2')) {
+//    $sql = "DROP TABLE tripal_expiration_files";
+//    db_query($sql);
+//    db_rename_table('tripal_expiration_files2', 'tripal_expiration_files');
+//  }
+//
+//  // schema change
+//  if (!db_field_exists('tripal_jobs', 'includes')) {
+//    $sql = "ALTER TABLE tripal_jobs ADD COLUMN includes text";
+//    db_query($sql);
+//  }
+//
+//  tripal_add_variables();
+//}
 
 /**
  * Implementation of hook_schema().


### PR DESCRIPTION
Issue #25 

This PR upgrades the tripal 3 install file to Drupal 8.

#### Changes
- Removed the following tables
  - tripal_vocab
  - tripal_bundle
  - tripal_term
  - tripal_entity
  - tripal_bundle_variables
- Updated install function to use new DB class to check for missing tripal_jobs column
- Removed update_xxxx functions
- Updated installed function to add new `Data Search` menu

#### Testing
- On a new Drupal 8 installation, clone this repo and switch to branch `d8-tv4-install_file`
- Run `drush en tripal`
- Check the menus page to make sure `Data Search` appears as an item (`/admin/structure/menu`)
- Check the database to make sure the following tables exist:
  - tripal_jobs
  - tripal_token_formats
  - tripal_variables
  - tripal_expiration_files
  - tripal_custom_quota
  - tripal_import
  - tripal_collection
  - tripal_collection_bundle
  - tripal_admin_notfications


#### Notes

I couldn't find a way to delete the `data_search` menu upon uninstall so that's something that might need to be added later. However, when uninstalling then re-installing, no errors show up.