### PR TITLE
Fix spelling of table tripal_admin_notfications

### DIFF
--- a/tripal/tripal.install
+++ b/tripal/tripal.install
@@ -173,7 +173,7 @@ function tripal_schema() {
   $schema['tripal_collection_bundle'] = tripal_tripal_collection_bundle_schema();
 
   // Adds a table for administrative notifications on the dashboard.
-  $schema['tripal_admin_notfications'] = tripal_tripal_admin_notifications_schema();
+  $schema['tripal_admin_notifications'] = tripal_tripal_admin_notifications_schema();
   return $schema;
 }
 
@@ -638,4 +638,47 @@ function tripal_tripal_admin_notifications_schema() {
   ];
 
   return $schema;
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * Fixes spelling of table tripal_admin_notfications and its associated indexes
+ * and sequences.
+ */
+function tripal_update_8401() {
+  $db = \Drupal::database();
+  $messenger = \Drupal::messenger();
+  $count = $db->select('information_schema.tables', 't')
+    ->fields('t')
+    ->condition('table_name', 'tripal_admin_notfications')
+    ->countQuery()
+    ->execute()->fetchField();
+
+  if ($count) {
+    $db->query('ALTER TABLE tripal_admin_notfications RENAME TO tripal_admin_notifications;');
+    $messenger->addMessage('Renamed table tripal_admin_notfications to tripal_admin_notifications.');
+  }
+
+  $count = $db->select('information_schema.sequences', 's')
+    ->fields('s')
+    ->condition('sequence_name', 'tripal_admin_notfications_note_id_seq')
+    ->countQuery()
+    ->execute()->fetchField();
+
+  if ($count) {
+    $db->query('ALTER SEQUENCE tripal_admin_notfications_note_id_seq RENAME TO tripal_admin_notifications_note_id_seq;');
+    $messenger->addMessage('Renamed sequence tripal_admin_notfications_note_id_seq to tripal_admin_notifications_note_id_seq.');
+  }
+
+  $count = $db->select('pg_indexes', 'i')
+    ->fields('i')
+    ->condition('indexname', 'tripal_admin_notfications____pkey')
+    ->countQuery()
+    ->execute()->fetchField();
+
+  if ($count) {
+    $db->query('ALTER INDEX tripal_admin_notfications____pkey RENAME TO tripal_admin_notifications____pkey;');
+    $messenger->addMessage('Renamed index tripal_admin_notfications____pkey to tripal_admin_notifications____pkey.');
+  }
 }


### PR DESCRIPTION
Issue #41 

Also provide hook_update_N() for those who have already installed and want to easily rename the table.

To test, simply run a `drush updatedb` from your command line.