### PR TITLE
Do not allow custom machine names for Tripal Content Types.

### DIFF
--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -62,7 +62,7 @@ class TripalEntityTypeForm extends EntityForm {
       '#machine_name' => [
         'exists' => '\Drupal\tripal\Entity\TripalEntityType::load',
       ],
-      '#disabled' => !$tripal_entity_type->isNew(),
+      '#disabled' => TRUE,
     ];
     $form['id'] = [
       '#type' => 'hidden',


### PR DESCRIPTION
In response to #53:

This PR disabled the ability to change the machine name of a Tripal Content Type. This is the safest option since many extension modules built for Tripal 3 may make the assumption as Tripal3 did not allow you to set the machine name.