### PR TITLE
Correct typos and change cases in dev guide docs

### DIFF
--- a/docs/dev_guide/biodb/chado.rst
+++ b/docs/dev_guide/biodb/chado.rst
@@ -30,9 +30,9 @@ Chado_ is meant to be installed into a PostgreSQL database and is designed to ho
 Chado Installation
 --------------------
 
-When you install the Tripal Chado module you will be automatically prompted to install Chado. This creates a schema within your Drupal database to house the chado tables listed in the resources above. To install chado manually navigate to Structure > Tripal > Data Storage > Chado > Install Chado. Then just choose your version and run the associated Tripal job.
+When you install the Tripal Chado module you will be automatically prompted to install Chado. This creates a schema within your Drupal database to house the Chado tables listed in the resources above. To install Chado manually navigate to Structure > Tripal > Data Storage > Chado > Install Chado. Then just choose your version and run the associated Tripal job.
 
-If you need to install chado programatically, use the following service from within a fully bootstrapped Tripal site.
+If you need to install Chado programmatically, use the following service from within a fully bootstrapped Tripal site.
 
 .. code-block:: php
 	:caption: Installs Chado version 1.3 in a schema named 'chado'.

--- a/docs/dev_guide/cvterms.rst
+++ b/docs/dev_guide/cvterms.rst
@@ -6,7 +6,7 @@ Controlled vocabularies are simply a collection of agreed upon names (knowns as 
 
 Tripal and Chado both use controlled vocabularies extensively to categorize data and metadata. The use of controlled vocabulary terms also allows both Tripal and Chado to be extremely flexible while also remaining very descriptive with rich metadata.
 
-In Tripal, controlled vocabularies and their terms are Drupal content entities. This means they are managed similar to tripal content (i.e. biological data) and will not be sync'd between production and development instances.
+In Tripal, controlled vocabularies and their terms are Drupal content entities. This means they are managed similar to Tripal content (i.e. biological data) and will not be sync'd between production and development instances.
 
 In Tripal 4 specifically, Tripal Controlled Vocabularies and their terms are completely independent of Chado. However, for sites which choose to use Chado for controlled vocabularies (recommended) there is tight cross-linking available. This ensures we remain database agnostic while also encouraging close interaction between Tripal and Chado.
 

--- a/docs/dev_guide/lessons/create_cvterms.rst
+++ b/docs/dev_guide/lessons/create_cvterms.rst
@@ -2,11 +2,11 @@
 Controlled Vocabulary Terms Create/Load
 =========================================
 
-This lesson will teach you how to programatically create new controlled vocabularies (CVs) and their terms (CVterms). It will also show you how to load both CVs and CVterms which already exist in your Tripal site.
+This lesson will teach you how to programmatically create new controlled vocabularies (CVs) and their terms (CVterms). It will also show you how to load both CVs and CVterms which already exist in your Tripal site.
 
 .. warning::
 
-  This lesson was written before Chado integration. As such it shows how database agnostic Tripal 4 is. In the future we will add a section about how to connect these terms to your Chado cvterms and how to create terms from those existing in chado.
+  This lesson was written before Chado integration. As such it shows how database agnostic Tripal 4 is. In the future we will add a section about how to connect these terms to your Chado cvterms and how to create terms from those existing in Chado.
 
 .. note::
 
@@ -20,7 +20,7 @@ Controlled Vocabularies (CVs)
   **Background:** :doc:`/dev_guide/cvterms`
 
   Questions:
-    - How do I programatically create a controlled vocabulary?
+    - How do I programmatically create a controlled vocabulary?
     - How do I load existing controlled vocabularies?
     - How do I access values once I have the vocabulary?
 
@@ -85,7 +85,7 @@ Controlled Vocabulary Terms (CVterms)
   **Background:** :doc:`/dev_guide/cvterms`
 
   Questions:
-    - How do I programatically add a term to an existing vocabulary.
+    - How do I programmatically add a term to an existing vocabulary.
     - How do I load an existing CVterm?
     - How do I access values once I have the term?
 

--- a/docs/dev_guide/module_dev/entities.rst
+++ b/docs/dev_guide/module_dev/entities.rst
@@ -12,7 +12,7 @@ In Drupal terminology, each Tripal content page is an content entity (e.g. MyFav
 
 This architecture allows you to categorize your data by type (e.g. gene versus germplasm variety) and provide specialized displays specific to each type.
 
-Both Tripal content and Tripal content types can be created through the administrative user interface or programatically. Tripal content entities and entity types have been extended to provide functionality specific to biological data. As such we recommend you create custom Tripal Content types rather then using the Drupal API directly.
+Both Tripal content and Tripal content types can be created through the administrative user interface or programmatically. Tripal content entities and entity types have been extended to provide functionality specific to biological data. As such we recommend you create custom Tripal Content types rather then using the Drupal API directly.
 
 Additional Resources:
  - `Official Drupal Docs: What are Content Entities and Fields <https://www.drupal.org/docs/user_guide/en/planning-data-types.html>`_

--- a/docs/dev_guide/module_dev/file_structure.rst
+++ b/docs/dev_guide/module_dev/file_structure.rst
@@ -14,7 +14,7 @@ Choose a module machine name that is descriptive, short and unique. It is always
  - It must be unique. Your module should not have the same short name as any other module, theme, or installation profile you will be using on the site.
  - It should not be any of the reserved terms : src, lib, vendor, assets, css, files, images, js, misc, templates, includes, fixtures, Drupal.
 
-It is also a good idea to ensure your module name encompases the full functionality you would like to develop. For example, while your current goal may be importing a specific file format, you are likely to want to develop customized display through Tripal fields in the future. As such, you would want to stay away from ``my_file_format_importer`` and go with something more general like ``my_data_type``. We also recommend you prefix your module name with a short identifier for you lab. This will ensure your module name is unique.
+It is also a good idea to ensure your module name encompasses the full functionality you would like to develop. For example, while your current goal may be importing a specific file format, you are likely to want to develop customized display through Tripal fields in the future. As such, you would want to stay away from ``my_file_format_importer`` and go with something more general like ``my_data_type``. We also recommend you prefix your module name with a short identifier for you lab. This will ensure your module name is unique.
 
 Prepare a module skeleton
 ---------------------------
@@ -48,7 +48,7 @@ As mentioned when preparing a module skeleton above, your entire module will be 
 
  - ``config``: contains files defining default configuration including variables and schema.
  - ``src``: contains the bulk of your module including controllers, forms, fields and blocks.
- - ``templates``: contains your Twig template files for mofifying display of fields and pages.
+ - ``templates``: contains your Twig template files for modifying display of fields and pages.
  - ``tests``: contains your automated phpunit tests.
 
 The sub-directories and files within are described in the following image:

--- a/docs/dev_guide/module_dev/routing.rst
+++ b/docs/dev_guide/module_dev/routing.rst
@@ -17,7 +17,7 @@ Defining URL paths and the programmatic flow to a rendered webpage is known as *
 
 This route defines that a user navigating to ``https://yourdrupalsite/hello`` will render the content defined by the ``helloWorld`` method in the ``HelloWorldController`` class. The ``defaults`` key provides parameters to the handlers responsible for returning your content to the user. In this case, that includes the title of the page and where to get the content from. Finally, the ``requirements`` key defines conditions which must be met for the content to display; for example, permissions that the current user must have.
 
-The other key thing to note about the above route is the ``{{name}}`` placeholder used in the path. By surrounding a variable name in curly brackets you can pass paramters to your controller. The important thing to note is that the name of your path variable must match exactly and exist in your specified controller method (i.e. ``HelloWorldController::helloWorld($name)``).
+The other key thing to note about the above route is the ``{{name}}`` placeholder used in the path. By surrounding a variable name in curly brackets you can pass parameters to your controller. The important thing to note is that the name of your path variable must match exactly and exist in your specified controller method (i.e. ``HelloWorldController::helloWorld($name)``).
 
 
 Additional Resources:
@@ -29,7 +29,7 @@ Additional Resources:
 Menu Items
 -------------
 
-The menu system has an extensive user interface (UI) for defining menus and the links within them. This is great for management for your Tripal site as it allows you to dynamically add menu items requested by your community. However, when developing custom modules, you will also want to define these menu items programatically to save time and provide navigation to other sites using your module. To do this you will want to use the ``.links.menu.yml`` file which lives in the base directory of your module. It looks like this:
+The menu system has an extensive user interface (UI) for defining menus and the links within them. This is great for management for your Tripal site as it allows you to dynamically add menu items requested by your community. However, when developing custom modules, you will also want to define these menu items programmatically to save time and provide navigation to other sites using your module. To do this you will want to use the ``.links.menu.yml`` file which lives in the base directory of your module. It looks like this:
 
 .. code::
 
@@ -57,7 +57,7 @@ Additional Resources
 Links
 ------
 
-When programatically creating page content, you will often want to add links. To add internal links, use the route name as shown below. This ensures that your link doesn't break if the route is changed.
+When programmatically creating page content, you will often want to add links. To add internal links, use the route name as shown below. This ensures that your link doesn't break if the route is changed.
 
 .. code:: php
 
@@ -71,7 +71,7 @@ To generate a link to an external resource, you can use the following:
   $link = Link::fromTextAndUrl('This is a link',
     Url::fromUri('http://www.google.com'));
 
-For all the different ways to generate URLs see the following resources -the tutorial is particularily complete.
+For all the different ways to generate URLs see the following resources -the tutorial is particularly complete.
 
 Additional Resources
  - `Agaric Tutorial: Creating Links in Code for Drupal 8 <https://agaric.coop/blog/creating-links-code-drupal-8>`_

--- a/docs/dev_guide/module_dev/theme.rst
+++ b/docs/dev_guide/module_dev/theme.rst
@@ -2,14 +2,14 @@
 Theme (display)
 =================
 
-Themeing is the process of customizing the display of pages or fields. Drupal 8 themeing is a two part process, as described below. Tripal uses the Drupal themeing system without alteration.
+Theming is the process of customizing the display of pages or fields. Drupal 8 theming is a two part process, as described below. Tripal uses the Drupal theming system without alteration.
 
 1. Use ``hook_theme`` to tell Drupal about your custom template. This hook implementation should go in your ``my_module.module`` file.
 2. Use the preprocess hook to use prepare your variables and do any processing needed.
 3. Finally, you use Twig templates to format the HTML and insert the variables prepared in the preprocess hook. No processing should be done in these templates.
 
 Additional Resources:
- - `Official Drupal Docs: Themeing in your custom module <https://www.drupal.org/docs/8/creating-custom-modules/theming>`_
+ - `Official Drupal Docs: Theming in your custom module <https://www.drupal.org/docs/8/creating-custom-modules/theming>`_
  - `Official Drupal Docs: Create custom twig templates for custom module <https://www.drupal.org/docs/8/theming/twig/create-custom-twig-templates-for-custom-module>`_
  - `Official Drupal Docs: Working With Twig Templates <https://www.drupal.org/docs/8/theming/twig/working-with-twig-templates>`_
  - `Official Drupal Docs: Defining a custom theme <https://www.drupal.org/docs/8/theming>`_


### PR DESCRIPTION
Resolved typos in the development guide documentation pages for better readability. Also changed cases for references to "Tripal" and "Chado" to make them more consistent with similar references in the documentation. 