### PR TITLE
Resolve errors and cases in comments of API docs

### DIFF
--- a/tripal/api/tripal.entities.api.php
+++ b/tripal/api/tripal.entities.api.php
@@ -105,7 +105,7 @@ function tripal_get_entity_tokens($bundle, $options = []) {
  * @param TripalEntity $entity
  *   The entity with field values used to find values of tokens.
  * @param TripalBundle $bundle_entity
- *   The bundle enitity containing special values sometimes needed for token
+ *   The bundle entity containing special values sometimes needed for token
  *   replacement.
  *
  * @return

--- a/tripal/api/tripal.files.api.php
+++ b/tripal/api/tripal.files.api.php
@@ -23,7 +23,7 @@
  * installation of the module in the .install file.  However this causes
  * permission problems if the module is installed via drush with a
  * user account that is not the same as the web user.  Therefore, this
- * function should not be called in a location accessiblve via a drush
+ * function should not be called in a location accessible via a drush
  * command.  The tripal_get_files_dir() and tripal_get_files_stream()
  * will automatically create the directory if it doesn't exist so there is
  * little need to call this function directly.

--- a/tripal/api/tripal.notice.api.php
+++ b/tripal/api/tripal.notice.api.php
@@ -12,7 +12,7 @@
  * @ingroup tripal_api
  * @{
  * Provides an application programming interface (API) for improved user
- * notivications.  These API functions can be used to set messages for
+ * notifications.  These API functions can be used to set messages for
  * end-users, administrators, or simple logging.
  *
  * @}
@@ -39,7 +39,7 @@ define('TRIPAL_DEBUG', 7);
  * will add backtrace information to the message.
  *
  * @param $type
- *   The catagory to which this message belongs. Can be any string, but the
+ *   The category to which this message belongs. Can be any string, but the
  *   general practice is to use the name of the module.
  * @param $severity
  *   The severity of the message; one of the following values:

--- a/tripal/api/tripal.quotas.api.php
+++ b/tripal/api/tripal.quotas.api.php
@@ -41,7 +41,7 @@ function tripal_get_user_quota($uid) {
  *  The User ID for whom the quota will be set.
  * @param $quota
  *  The quota
- * @param int $expriation
+ * @param int $expiration
  *   The expiration timestamp
  *
  * @return int The inserted record.

--- a/tripal/api/tripal.terms.api.php
+++ b/tripal/api/tripal.terms.api.php
@@ -22,12 +22,12 @@ use \Drupal\tripal\Entity\TripalTerm;
  *         prefix does not support appending then the exact location for the
  *         position of the short_name and the term accession will be
  *         specified with the {db} and {accession} tags respectively.
- *       - TripalVocab: the tripal vocabulary object.
+ *       - TripalVocab: the Tripal vocabulary object.
  *     - accession : The name unique ID of the term.
  *     - url : The URL for the term.
  *     - name : The name of the term.
  *     - definition : The term's description.
- *     - TripalTerm: the tripal term object.
+ *     - TripalTerm: the Tripal term object.
  *   Returns NULL if the term cannot be found.
  *
  * @ingroup tripal_terms_api

--- a/tripal/api/tripal.upload.api.php
+++ b/tripal/api/tripal.upload.api.php
@@ -87,7 +87,7 @@
  *
  *
  * 3) Files are uploaded automatically to Tripal.  Files are saved in the
- * Tripal user's directory.  You can retreive information about the
+ * Tripal user's directory.  You can retrieve information about the
  * file by querying for the file category for the current project.
  *
  * @code
@@ -107,12 +107,12 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 /**
  * Allows a module to interact with the Tripal file uploader during upload.
  *
- * This function is called prior to an 'action' aoccuring and allows the
+ * This function is called prior to an 'action' occurring and allows the
  * module that is responsible for the file upload to halt an upload if
  * needed.
  *
  * @param $action
- *   The current action that is being peformed during the upload process. The
+ *   The current action that is being performed during the upload process. The
  *   actions are:  'save', 'check' and 'merge'.
  * @param $details
  *   An associative array containing details about the upload process. Valid
@@ -136,7 +136,7 @@ function hook_file_upload_check($action, $details, &$message) {
       // Place code here when chunks are being saved.
       break;
     case 'check':
-      // Place code here when a chunck is being checked if the upload
+      // Place code here when a chunk is being checked if the upload
       // completed successfully.
       break;
     case 'merge':
@@ -440,7 +440,7 @@ function tripal_file_upload_merge($filename, $type, $user_dir) {
         $chunks_written = $log['chunks_written'];
         $max_chunk = max(array_keys($chunks_written));
         // Iterate through the chunks in order and see if any are missing.
-        // If so then break out of the loop and fail. Otherwise concatentate
+        // If so then break out of the loop and fail. Otherwise concatenate
         // them together.
         for ($i = 0; $i <= $max_chunk; $i++) {
           if (!array_key_exists($i, $chunks_written)) {


### PR DESCRIPTION
Resolved errors in the form of typos found in the comments of the API files to improve readability. Also changed cases to certain references to "Tripal" in comments to make them consistent with other reference instances.