### PR TITLE
Issue 63: Instead of blank page, show link to begin by creating vocabulaties

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -46,5 +46,5 @@ jobs:
           docker exec -e SIMPLETEST_BASE_URL=$SIMPLETEST_BASE_URL \
             -e SIMPLETEST_DB=$SIMPLETEST_DB \
             -e BROWSER_OUTPUT_DIRECTORY=$BROWSER_OUTPUT_DIRECTORY \
-            tripaldocker phpunit --printer mheap\\GithubActionsReporter\\Printer \
-              --configuration core modules/contrib/tripal
+            --workdir=/var/www/drupal8/web/modules/contrib/tripal \
+            tripaldocker phpunit --printer mheap\\GithubActionsReporter\\Printer

--- a/tripal/src/Controller/TripalEntityUIController.php
+++ b/tripal/src/Controller/TripalEntityUIController.php
@@ -5,6 +5,7 @@ namespace Drupal\tripal\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Drupal\Core\Url;
+use Drupal\Core\Link;
 
 /**
  * Controller routines related to Tripal Entity and Tripal Entity Type UIs.
@@ -48,14 +49,21 @@ class TripalEntityUIController extends ControllerBase {
 
     // If there are no tripal content types / bundles
     if (count($bundle_entities) <= 0) {
-      $bundles['tripal_content_types']['title'] = 'Tripal Content Types';
-      $bundles['tripal_content_types']['members'][] = [
-        'title' => 'There are no tripal content types, please begin by ' .
-                   'creating a vocabulary.',
-        'help' => '',
-        'url' => Url::fromRoute('entity.tripal_vocab.collection'),
-      ];
+      $url_vocab_management = Url::fromRoute('entity.tripal_vocab.collection');
+      $link = Link::fromTextAndUrl('creating a vocabulary', 
+                $url_vocab_management)->toString();
+
+      // Because this message contains a link, we need to render it before
+      // displaying it using the messenger. 
+      $message = 'There are currently no tripal content types, ' .
+                 'please begin by ' . $link . '.';
+      $rendered_message = \Drupal\Core\Render\Markup::create($message);
+
+      // Display the message to create a vocabulary
+      $messenger = \Drupal::messenger();
+      $messenger->addMessage($rendered_message,'warning');
     }
+    
 
     // Finally, let tripal-entity-content-add-list.html.twig add the markup.
     return [

--- a/tripal/src/Controller/TripalEntityUIController.php
+++ b/tripal/src/Controller/TripalEntityUIController.php
@@ -33,6 +33,7 @@ class TripalEntityUIController extends ControllerBase {
       ->getStorage('tripal_entity_type')
       ->loadByProperties([]);
 
+
     // Now compile them into variables to be used in twig.
     $bundles = [];
     foreach ($bundle_entities as $entity) {
@@ -42,6 +43,17 @@ class TripalEntityUIController extends ControllerBase {
         'title' => $entity->getLabel(),
         'help' => $entity->getHelpText(),
         'url' => Url::fromRoute('entity.tripal_entity.add_form', ['tripal_entity_type' => $entity->getName()]),
+      ];
+    }
+
+    // If there are no tripal content types / bundles
+    if (count($bundle_entities) <= 0) {
+      $bundles['tripal_content_types']['title'] = 'Tripal Content Types';
+      $bundles['tripal_content_types']['members'][] = [
+        'title' => 'There are no tripal content types, please begin by ' .
+                   'creating a vocabulary.',
+        'help' => '',
+        'url' => Url::fromRoute('entity.tripal_vocab.collection'),
       ];
     }
 

--- a/tripal/tests/src/Functional/TripalContentTest.php
+++ b/tripal/tests/src/Functional/TripalContentTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\Tests\tripal\Functional;
+
+use Drupal\tripal\Entity\TripalVocab;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Core\Url;
+
+/**
+ * Tests the basic functions of Tripal Content.
+ *
+ * @group Tripal
+ * @group Tripal Content
+ */
+class TripalContentTest extends BrowserTestBase {
+    protected $defaultTheme = 'stable';
+
+    public static $modules = ['tripal', 'block', 'field_ui'];
+
+  /**
+   * Basic tests for Tripal Content Types.
+   *
+   * @group tripal_content
+   */
+  public function testTripalEmptyContentTypes() {
+    $assert = $this->assertSession();
+
+    $web_user = $this->drupalCreateUser([
+      'administer tripal',
+      'view controlled vocabulary entities'
+    ]);
+
+    // Anonymous User should not see this content type add page.
+    $this->drupalGet('bio_data/add');
+    $assert->pageTextContains('Access denied');
+
+    // Perform a user login with the permissions specified above
+    $this->drupalLogin($web_user);
+
+    // First check that the link shows up to create new vocabulary
+    // if the page contains no content types / bundles
+    $this->drupalGet('bio_data/add');
+    $assert->pageTextContains('There are currently no tripal content types');
+    $assert->linkExists('creating a vocabulary');
+
+    // Visit the link for creating a vocabulary and make sure it loads
+    $this->clickLink('creating a vocabulary'); 
+    $assert->pageTextContains('tripal vocabulary');
+    
+  }
+
+}


### PR DESCRIPTION
Add a link if there are no bundle entities / empty page that advises the user to begin creating vocabularies.