### PR TITLE
Fix tripal admin links not loading properly 

### DIFF
--- a/tripal/tripal.links.menu.yml
+++ b/tripal/tripal.links.menu.yml
@@ -44,6 +44,12 @@ tripal.cv_lookup:
 ##
 # Tripal Admin menu
 ##
+tripal.admin:
+  route_name: tripal.admin
+  title: 'Tripal'
+  description: 'Manage the behavior or Tripal and its various modules.'
+  parent: system.admin
+
 tripal.admin_register:
   route_name: tripal.admin_register
   title: 'Tripal Registration'


### PR DESCRIPTION
The Tripal admin links/pages show "You do not have any administrative items" instead of the appropriate administrative sub links to perform tripal admin tasks.

Reference issue: https://github.com/tripal/t4d8/issues/105