### PR TITLE
Chado setup prepare

### DIFF
--- a/tripal/src/Services/TripalLogger.php
+++ b/tripal/src/Services/TripalLogger.php
@@ -544,9 +544,9 @@ class TripalLogger {
       if (!array_key_exists('logger', $options) or $options['logger'] !== FALSE) {
         $this->logger->debug($message, $context);
       }
-    }
 
-    $this->log2Server($message, $context, $options);
+      $this->log2Server('DEBUG: ' . $message, $context, $options);
+    }
   }
 
   /**

--- a/tripal_chado/src/Form/ChadoPrepareForm.php
+++ b/tripal_chado/src/Form/ChadoPrepareForm.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\tripal_chado\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+
+class ChadoPrepareForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'chado_prepare_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    if (\Drupal::state()->get('tripal_chado_is_prepared') == TRUE) {
+      \Drupal::messenger()->addMessage('Your site is prepared.');
+    }
+
+    $form['instructions'] = [
+      '#type' => 'item',
+      '#title' => 'Prepare Drupal for Chado.',
+      '#description' => t("Before a Drupal site can use Chado (via Tripal), both
+        Chado and Drupal must be prepared a bit more.  Tripal will add some new
+        materialized views, custom tables and controlled vocabularies to Chado.
+        It will also add some management tables to Drupal and add some default
+        content types for biological and ancillary data."),
+    ];
+
+    $form['advanced']['schema_name'] = [
+      '#type' => 'textfield',
+      '#title' => 'Chado Schema Name',
+      '#required' => TRUE,
+      '#description' => 'The name of the schema to install chado in.',
+      '#default_value' => 'chado',
+    ];
+
+    $form['prepare-button'] = [
+      '#type' => 'submit',
+      '#value' => t('Prepare this site'),
+      '#name' => 'prepare-chado',
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    if ($form_state->getTriggeringElement()['#name'] == 'prepare-chado') {
+      $schema_name = trim($form_state->getValues()['schema_name']);
+      $current_user = \Drupal::currentUser();
+      $args = [$schema_name];
+
+      tripal_add_job('Prepare Chado', 'tripal_chado',
+        'tripal_chado_prepare_chado', $args, $current_user->id(), 10);
+    }
+  }
+}

--- a/tripal_chado/src/Services/chadoPreparer.php
+++ b/tripal_chado/src/Services/chadoPreparer.php
@@ -27,24 +27,65 @@ class ChadoPreparer {
   protected $job = NULL;
 
   /**
-   *
+   * Constructor: initialize connections.
    */
   public function __construct() {
+    $this->connection = \Drupal::database();
 
+    // Initialize the logger.
+    $this->logger = \Drupal::service('tripal.logger');
+  }
+
+  /**
+   * Set the schema name.
+   */
+  public function setSchema($schema_name) {
+    // Schema name must be all lowercase with no special characters.
+    // It should also be a single word.
+    if (preg_match('/^[a-z][a-z0-9]+$/', $schema_name) === 0) {
+      $this->logger->error('The schema name must be a single word containing only lower case letters or numbers and cannot begin with a number.');
+      return FALSE;
+    }
+    else {
+      $this->logger->info('Setting Schema to "' . $schema_name . '".');
+      $this->schemaName = $schema_name;
+      return TRUE;
+    }
+}
+
+  /**
+   * A setter for the job object if this class is being run using a Tripal job.
+   */
+  public function setJob(\Drupal\tripal\Services\TripalJob $job) {
+    $this->job = $job;
+    $this->logger->setJob($job);
+    return TRUE;
+  }
+
+  /**
+   * Retrieve the Drupal connection to the database.
+   *
+   * @return Drupal\database
+   *   Current Drupal connection.
+   */
+  public function getDrupalConnection() {
+    return $this->connection;
+  }
+
+  /**
+   * Retrieves the message logger.
+   *
+   * @return object
+   *
+   */
+  public function getLogger() {
+    return $this->logger;
   }
 
   /**
    *
    */
-  public function setSchema($schema_name) {}
+  public function prepare() {
 
-  /**
-   *
-   */
-  public function setJob(\Drupal\tripal\Services\TripalJob $job) {}
-
-  /**
-   *
-   */
-  public function prepare() {}
+  }
 }

--- a/tripal_chado/src/Services/chadoPreparer.php
+++ b/tripal_chado/src/Services/chadoPreparer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\tripal_chado\Services;
+
+use Drupal\Core\Database\Database;
+
+class ChadoPreparer {
+
+  /**
+   * The name of the schema we are interested in installing/updating chado for.
+   */
+  protected $schemaName;
+
+  /**
+   * The DRUPAL-managed database connection.
+   */
+  protected $connection;
+
+  /**
+   * The drupal logger for tripal.
+   */
+  protected $logger;
+
+  /**
+   * Holds the Job object
+   */
+  protected $job = NULL;
+
+  /**
+   *
+   */
+  public function __construct() {
+
+  }
+
+  /**
+   *
+   */
+  public function setSchema($schema_name) {}
+
+  /**
+   *
+   */
+  public function setJob(\Drupal\tripal\Services\TripalJob $job) {}
+
+  /**
+   *
+   */
+  public function prepare() {}
+}

--- a/tripal_chado/src/Services/chadoPreparer.php
+++ b/tripal_chado/src/Services/chadoPreparer.php
@@ -101,8 +101,8 @@ class ChadoPreparer {
     \Drupal::service('tripal.tripalVocab.manager')->addVocabulary([
       'idspace' => 'NCIT',
       'namespace' => 'ncit',
-      'name' => 'The NCIt OBO Edition project aims to increase integration of the NCIt with OBO Library ontologies. NCIt is a reference terminology that includes broad coverage of the cancer domain, including cancer related diseases, findings and abnormalities. NCIt OBO Edition releases should be considered experimental.',
-      'description' => 'NCI Thesaurus OBO Edition.',
+      'name' => 'NCI Thesaurus OBO Edition',
+      'description' => 'The NCIt OBO Edition project aims to increase integration of the NCIt with OBO Library ontologies.',
       'url' => 'http://purl.obolibrary.org/obo/ncit.owl',
       'urlprefix' => ' http://purl.obolibrary.org/obo/{db}_{accession}',
     ]);
@@ -111,7 +111,7 @@ class ChadoPreparer {
       'accession' => 'C25693',
       'name' => 'Subgroup',
       'vocabulary' => [
-        'name' => 'ncit',
+        'namespace' => 'ncit',
         'idspace' => 'NCIT',
       ],
       'definition' => 'A subdivision of a larger group with members often exhibiting similar characteristics. [ NCI ]',
@@ -121,7 +121,7 @@ class ChadoPreparer {
       'idspace' => 'rdfs',
       'namespace' => 'rdfs',
       'name' => 'Resource Description Framework Schema',
-      'description' => 'Resource Description Framework Schema',
+      'description' => 'RDF Schema provides a data-modelling vocabulary for RDF data.',
       'url' => 'https://www.w3.org/TR/rdf-schema/',
       'urlprefix' => 'http://www.w3.org/2000/01/rdf-schema#{accession}',
     ]);
@@ -130,7 +130,7 @@ class ChadoPreparer {
       'accession' => 'comment',
       'name' => 'comment',
       'vocabulary' => [
-        'name' => 'rdfs',
+        'namespace' => 'rdfs',
         'idspace' => 'rdfs',
       ],
       'definition' => 'A human-readable description of a resource\'s name.',
@@ -138,40 +138,92 @@ class ChadoPreparer {
 
     // TODO:
     // T3 loads many terms we need for default content types through the OBO
-    // Importer. As of Jan 12 2021 the OBO importer has not yet been migrated
+    // Importer. As of April 19, 2021 the OBO importer has not yet been migrated
     // to T4 and therefore cannot be used. As a result, I will be adding a few
     // terms here individually using the vocab and term managers. In the
     // future, this should be replaced with calls to the OBO importer so that
     // the terms can be imported automatically.
+    $terms = [];
 
-    // accession|name|dbname|cvname|cvdesc|dbdesc|url|urlprefix|definition
-    $terms = [
-      '0100026|organism|OBI|obi|Ontology for Biomedical Investigation. The Ontology for Biomedical Investigations (OBI) is build in a collaborative, international effort and will serve as a resource for annotating biomedical investigations, including the study design, protocols and instrumentation used, the data generated and the types of analysis performed on the data. This ontology arose from the Functional Genomics Investigation Ontology (FuGO) and will contain both terms that are common to all biomedical investigations, including functional genomics investigations and those that are more domain specific.|The Ontology for Biomedical Investigation.|http://obi-ontology.org/page/Main_Page|http://purl.obolibrary.org/obo/{db}_{accession}|A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.',
-      '0000704|gene|SO|sequence|The sequence ontology.|The sequence ontology.|http://www.sequenceontology.org/|http://www.sequenceontology.org/browser/current_svn/term/{db}:{accession}',
-      '0000044|accession|CO_010|germplasm_ontology|GCP germplasm ontology|Crop Germplasm Ontology|http://www.cropontology.org/get-ontology/CO_010|http://www.cropontology.org/terms/CO_010:{accession}',
-      '2945|Analysis|operation|EDAM|EDAM is an ontology of well established, familiar concepts that are prevalent within bioinformatics, including types of data and data identifiers, data formats, operations and topics. EDAM is a simple ontology - essentially a set of terms with synonyms and definitions - organised into an intuitive hierarchy for convenient use by curators, software developers and end-users. EDAM is suitable for large-scale semantic annotations and categorization of diverse bioinformatics resources. EDAM is also suitable for diverse application including for example within workbenches and workflow-management systems, software distributions, and resource registries|A function that processes a set of inputs and results in a set of outputs, or associates arguments (inputs) with values (outputs). Special cases are: a) An operation that consumes no input (has no input arguments).|http://edamontology.org/page|http://edamontology.org/{db}_{accession}|Apply analytical methods to existing data of a specific type.',
+    // Organism.
+    $terms['SO:0100026'] = [
+      'accession' => '0100026',
+      'name' => 'organism',
+      'definition' => 'A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.',
+      'vocabulary' => [
+        'name' => 'The Ontology for Biomedical Investigation',
+        'namespace' => 'obi',
+        'idspace' => 'OBI',
+        'description' => 'The Ontology for Biomedical Investigations (OBI) will serve as a resource for annotating biomedical investigations, including the study design, protocols and instrumentation used, the data generated and the types of analysis performed on the data.',
+        'url' => 'http://obi-ontology.org/page/Main_Page',
+        'urlprefix' => 'http://purl.obolibrary.org/obo/{db}_{accession}',
+      ],
     ];
 
-    foreach ($terms as $term) {
-      $term = explode('|', $term);
-      \Drupal::service('tripal.tripalVocab.manager')->addVocabulary([
-        'idspace' => $term[2],
-        'namespace' => $term[3],
-        'name' => $term[4],
-        'description' => $term[5],
-        'url' => $term[6],
-        'urlprefix' => $term[7],
-      ]);
+    // Gene.
+    $terms['SO:0000704'] = [
+      'accession' => '0000704',
+      'name' => 'gene',
+      'definition' => 'A region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene may include regulatory regions, transcribed regions and/or other functional sequence regions.',
+      'vocabulary' => [
+        'name' => 'The Sequence Ontology',
+        'namespace' => 'sequence',
+        'idspace' => 'SO',
+        'description' => 'The Sequence Ontology (SO) is a collaborative ontology project for the definition of sequence features used in biological sequence annotation.',
+        'url' => 'http://www.sequenceontology.org/',
+        'urlprefix' => 'http://www.sequenceontology.org/browser/current_svn/term/{db}:{accession}',
+      ],
+    ];
 
-      \Drupal::service('tripal.tripalTerm.manager')->addTerm([
-        'accession' => $term[0],
-        'name' => $term[1],
-        'vocabulary' => [
-          'name' => $term[3],
-          'idspace' => $term[2],
-        ],
-        'definition' => $term[8],
-      ]);
+    // Germplasm Accession.
+    $terms['CO_010:0000044'] = [
+      'accession' => '0000044',
+      'name' => 'accession',
+      'definition' => '',
+      'vocabulary' => [
+        'name' => 'GCP germplasm ontology',
+        'namespace' => 'germplasm_ontology',
+        'idspace' => 'CO_010',
+        'description' => 'Provides desciptors for germplasm collections. Adapted from Descriptors for Banana (Musa spp.) (1996) and Descriptors for Mango by Bioversity.',
+        'url' => 'http://www.cropontology.org/ontology/CO_010/Germplasm',
+        'urlprefix' => 'http://www.cropontology.org/terms/{db}:{accession}/index.html',
+      ],
+    ];
+
+    // Analysis.
+    $terms['2945'] = [
+      'accession' => '2945',
+      'name' => 'Analysis',
+      'definition' => 'Apply analytical methods to existing data of a specific type.',
+      'vocabulary' => [
+        'name' => 'EDAM - Ontology of bioscientific data analysis',
+        'namespace' => 'EDAM',
+        'idspace' => 'operation',
+        'description' => 'EDAM is a comprehensive ontology of well-established, familiar concepts that are prevalent within computational biology, bioinformatics, and bioimage informatics.',
+        'url' => 'http://edamontology.org/page',
+        'urlprefix' => 'http://edamontology.org/{db}_{accession}',
+      ],
+    ];
+
+    /* Template for adding more.
+    $terms[''] = [
+      'accession' => '',
+      'name' => '',
+      'definition' => '',
+      'vocabulary' => [
+        'name' => '',
+        'namespace' => '',
+        'idspace' => '',
+        'description' => '',
+        'url' => '',
+        'urlprefix' => '',
+      ],
+    ]; */
+
+    // Actually add the terms described above.
+    // The term manager will create the vocabulary if it doesn't exist.
+    foreach ($terms as $term) {
+      \Drupal::service('tripal.tripalTerm.manager')->addTerm($term);
     }
 
     // ###################################################################
@@ -271,11 +323,11 @@ class ChadoPreparer {
     ]);
 
     $organism = TripalEntityType::create([
-      'id' => 'organism',
-      'name' => 'organism',
+      'id' => 1,
+      'name' => 'bio_data_1',
       'label' => 'Organism',
       'term_id' => $term->getID(),
-      'help_text' => 'help',
+      'help_text' => $term->getDefinition(),
       'category' => 'General',
     ]);
     $organism->save();
@@ -291,23 +343,23 @@ class ChadoPreparer {
 
     $analysis = TripalEntityType::create([
       'id' => 2,
-      'name' => 'analysis',
+      'name' => 'bio_data_2',
       'label' => 'Analysis',
       'term_id' => $term->getID(),
-      'help_text' => 'help',
+      'help_text' => $term->getDefinition(),
       'category' => 'General',
     ]);
     $analysis->save();
 
-    // TODO: Create the 'Project' entity type.
+    // TODO: Create the 'Project' entity type. bio_data_3
 
-    // TODO: Create the 'Study' entity type.
+    // TODO: Create the 'Study' entity type. bio_data_4
 
-    // TODO: Create the 'Contact' entity type.
+    // TODO: Create the 'Contact' entity type. bio_data_5
 
-    // TODO: Create the 'Publication' entity type.
+    // TODO: Create the 'Publication' entity type. bio_data_6
 
-    // TODO: Create the 'Protocol' entity type.
+    // TODO: Create the 'Protocol' entity type. bio_data_7
   }
 
   /**
@@ -324,43 +376,43 @@ class ChadoPreparer {
     ]);
 
     $gene = TripalEntityType::create([
-      'id' => 'gene',
-      'name' => 'gene',
+      'id' => 8,
+      'name' => 'bio_data_8',
       'label' => 'Gene',
       'term_id' => $term->getID(),
-      'help_text' => 'help',
+      'help_text' => $term->getDefinition(),
       'category' => 'Genomic',
     ]);
     $gene->save();
 
-    // TODO: Create the 'mRNA' entity type.
+    // TODO: Create the 'mRNA' entity type. bio_data_9
 
-    // TODO: Create the 'Phylogenetic tree' entity type.
+    // TODO: Create the 'Phylogenetic tree' entity type. bio_data_10
 
-    // TODO: Create the 'Physical Map' entity type.
+    // TODO: Create the 'Physical Map' entity type. bio_data_11
 
-    // TODO: Create the 'DNA Library' entity type.
+    // TODO: Create the 'DNA Library' entity type. bio_data_12
 
-    // TODO: Create the 'Genome Assembly' entity type.
+    // TODO: Create the 'Genome Assembly' entity type. bio_data_13
 
-    // TODO: Create the 'Genome Annotation' entity type.
+    // TODO: Create the 'Genome Annotation' entity type. bio_data_14
 
-    // TODO: Create the 'Genome Project' entity type.
+    // TODO: Create the 'Genome Project' entity type. bio_data_15
   }
 
   /**
    * Creates the "Genetic" category of content types.
    */
   protected function geneticContentTypes() {
-    // TODO: Create the 'Genetic Map' entity type.
+    // TODO: Create the 'Genetic Map' entity type. bio_data_16
 
-    // TODO: Create the 'QTL' entity type.
+    // TODO: Create the 'QTL' entity type. bio_data_17
 
-    // TODO: Create the 'Sequence Variant' entity type.
+    // TODO: Create the 'Sequence Variant' entity type. bio_data_18
 
-    // TODO: Create the 'Genetic Marker' entity type.
+    // TODO: Create the 'Genetic Marker' entity type. bio_data_19
 
-    // TODO: Create the 'Heritable Phenotypic Marker' entity type.
+    // TODO: Create the 'Heritable Phenotypic Marker' entity type. bio_data_20
   }
 
   /**
@@ -379,30 +431,30 @@ class ChadoPreparer {
     ]);
 
     $germplasm_accession = TripalEntityType::create([
-      'id' => 'germplasm_accession',
-      'name' => 'germplasm_accession',
+      'id' => 21,
+      'name' => 'bio_data_21',
       'label' => 'Germplasm Accession',
       'term_id' => $term->getID(),
-      'help_text' => 'help',
+      'help_text' => $term->getDefinition(),
       'category' => 'Germplasm/Breeding',
     ]);
     $germplasm_accession->save();
 
-    // TODO: Create the 'Breeding Cross' entity type.
+    // TODO: Create the 'Breeding Cross' entity type. bio_data_22
 
-    // TODO: Create the 'Germplasm Variety' entity type.
+    // TODO: Create the 'Germplasm Variety' entity type. bio_data_23
 
-    // TODO: Create the 'Recombinant Inbred Line' entity type.
+    // TODO: Create the 'Recombinant Inbred Line' entity type. bio_data_24
   }
 
   /**
    * Creates the "Expression" category of content types.
    */
   protected function expressionContentTypes() {
-    // TODO: Create the 'biological sample' entity type.
+    // TODO: Create the 'biological sample' entity type. bio_data_25
 
-    // TODO: Create the 'Assay' entity type.
+    // TODO: Create the 'Assay' entity type. bio_data_26
 
-    // TODO: Create the 'Array Design' entity type.
+    // TODO: Create the 'Array Design' entity type. bio_data_27
   }
 }

--- a/tripal_chado/src/Services/chadoPreparer.php
+++ b/tripal_chado/src/Services/chadoPreparer.php
@@ -3,6 +3,7 @@
 namespace Drupal\tripal_chado\Services;
 
 use Drupal\Core\Database\Database;
+use Drupal\tripal\Entity\TripalEntityType;
 
 class ChadoPreparer {
 
@@ -86,6 +87,322 @@ class ChadoPreparer {
    *
    */
   public function prepare() {
+    $this->logger->info("Loading ontologies...");
+    $this->loadOntologies();
 
+    $this->logger->info("Creating default content types...");
+    $this->contentTypes();
+  }
+
+  /**
+   * Loads ontologies necessary for creation of default Tripal content types.
+   */
+  protected function loadOntologies() {
+    \Drupal::service('tripal.tripalVocab.manager')->addVocabulary([
+      'idspace' => 'NCIT',
+      'namespace' => 'ncit',
+      'name' => 'The NCIt OBO Edition project aims to increase integration of the NCIt with OBO Library ontologies. NCIt is a reference terminology that includes broad coverage of the cancer domain, including cancer related diseases, findings and abnormalities. NCIt OBO Edition releases should be considered experimental.',
+      'description' => 'NCI Thesaurus OBO Edition.',
+      'url' => 'http://purl.obolibrary.org/obo/ncit.owl',
+      'urlprefix' => ' http://purl.obolibrary.org/obo/{db}_{accession}',
+    ]);
+
+    \Drupal::service('tripal.tripalTerm.manager')->addTerm([
+      'accession' => 'C25693',
+      'name' => 'Subgroup',
+      'vocabulary' => [
+        'name' => 'ncit',
+        'idspace' => 'NCIT',
+      ],
+      'definition' => 'A subdivision of a larger group with members often exhibiting similar characteristics. [ NCI ]',
+    ]);
+
+    \Drupal::service('tripal.tripalVocab.manager')->addVocabulary([
+      'idspace' => 'rdfs',
+      'namespace' => 'rdfs',
+      'name' => 'Resource Description Framework Schema',
+      'description' => 'Resource Description Framework Schema',
+      'url' => 'https://www.w3.org/TR/rdf-schema/',
+      'urlprefix' => 'http://www.w3.org/2000/01/rdf-schema#{accession}',
+    ]);
+
+    \Drupal::service('tripal.tripalTerm.manager')->addTerm([
+      'accession' => 'comment',
+      'name' => 'comment',
+      'vocabulary' => [
+        'name' => 'rdfs',
+        'idspace' => 'rdfs',
+      ],
+      'definition' => 'A human-readable description of a resource\'s name.',
+    ]);
+
+    // TODO:
+    // T3 loads many terms we need for default content types through the OBO
+    // Importer. As of Jan 12 2021 the OBO importer has not yet been migrated
+    // to T4 and therefore cannot be used. As a result, I will be adding a few
+    // terms here individually using the vocab and term managers. In the
+    // future, this should be replaced with calls to the OBO importer so that
+    // the terms can be imported automatically.
+
+    // accession|name|dbname|cvname|cvdesc|dbdesc|url|urlprefix|definition
+    $terms = [
+      '0100026|organism|OBI|obi|Ontology for Biomedical Investigation. The Ontology for Biomedical Investigations (OBI) is build in a collaborative, international effort and will serve as a resource for annotating biomedical investigations, including the study design, protocols and instrumentation used, the data generated and the types of analysis performed on the data. This ontology arose from the Functional Genomics Investigation Ontology (FuGO) and will contain both terms that are common to all biomedical investigations, including functional genomics investigations and those that are more domain specific.|The Ontology for Biomedical Investigation.|http://obi-ontology.org/page/Main_Page|http://purl.obolibrary.org/obo/{db}_{accession}|A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.',
+      '0000704|gene|SO|sequence|The sequence ontology.|The sequence ontology.|http://www.sequenceontology.org/|http://www.sequenceontology.org/browser/current_svn/term/{db}:{accession}',
+      '0000044|accession|CO_010|germplasm_ontology|GCP germplasm ontology|Crop Germplasm Ontology|http://www.cropontology.org/get-ontology/CO_010|http://www.cropontology.org/terms/CO_010:{accession}',
+      '2945|Analysis|operation|EDAM|EDAM is an ontology of well established, familiar concepts that are prevalent within bioinformatics, including types of data and data identifiers, data formats, operations and topics. EDAM is a simple ontology - essentially a set of terms with synonyms and definitions - organised into an intuitive hierarchy for convenient use by curators, software developers and end-users. EDAM is suitable for large-scale semantic annotations and categorization of diverse bioinformatics resources. EDAM is also suitable for diverse application including for example within workbenches and workflow-management systems, software distributions, and resource registries|A function that processes a set of inputs and results in a set of outputs, or associates arguments (inputs) with values (outputs). Special cases are: a) An operation that consumes no input (has no input arguments).|http://edamontology.org/page|http://edamontology.org/{db}_{accession}|Apply analytical methods to existing data of a specific type.',
+    ];
+
+    foreach ($terms as $term) {
+      $term = explode('|', $term);
+      \Drupal::service('tripal.tripalVocab.manager')->addVocabulary([
+        'idspace' => $term[2],
+        'namespace' => $term[3],
+        'name' => $term[4],
+        'description' => $term[5],
+        'url' => $term[6],
+        'urlprefix' => $term[7],
+      ]);
+
+      \Drupal::service('tripal.tripalTerm.manager')->addTerm([
+        'accession' => $term[0],
+        'name' => $term[1],
+        'vocabulary' => [
+          'name' => $term[3],
+          'idspace' => $term[2],
+        ],
+        'definition' => $term[8],
+      ]);
+    }
+
+    // ###################################################################
+    // Begin T3 code to be converted to D8 when the OBO importer is ready.
+    // ###################################################################
+    /*
+      // Insert commonly used ontologies into the tables.
+      $ontologies = [
+        [
+          'name' => 'Relationship Ontology (legacy)',
+          'path' => '{tripal_chado}/files/legacy_ro.obo',
+          'auto_load' => FALSE,
+          'cv_name' => 'ro',
+          'db_name' => 'RO',
+        ],
+        [
+          'name' => 'Gene Ontology',
+          'path' => 'http://purl.obolibrary.org/obo/go.obo',
+          'auto_load' => FALSE,
+          'cv_name' => 'cellualar_component',
+          'db_name' => 'GO',
+        ],
+        [
+          'name' => 'Taxonomic Rank',
+          'path' => 'http://purl.obolibrary.org/obo/taxrank.obo',
+          'auto_load' => TRUE,
+          'cv_name' => 'taxonomic_rank',
+          'db_name' => 'TAXRANK',
+        ],
+        [
+          'name' => 'Tripal Contact',
+          'path' => '{tripal_chado}/files/tcontact.obo',
+          'auto_load' => TRUE,
+          'cv_name' => 'tripal_contact',
+          'db_name' => 'TContact',
+        ],
+        [
+          'name' => 'Tripal Publication',
+          'path' => '{tripal_chado}/files/tpub.obo',
+          'auto_load' => TRUE,
+          'cv_name' => 'tripal_pub',
+          'db_name' => 'TPUB',
+        ],
+        [
+          'name' => 'Sequence Ontology',
+          'path' => 'http://purl.obolibrary.org/obo/so.obo',
+          'auto_load' => TRUE,
+          'cv_name' => 'sequence',
+          'db_name' => 'SO',
+        ],
+      ];
+
+      module_load_include('inc', 'tripal_chado', 'includes/TripalImporter/OBOImporter');
+      for ($i = 0; $i < count($ontologies); $i++) {
+        $obo_id = chado_insert_obo($ontologies[$i]['name'], $ontologies[$i]['path']);
+        if ($ontologies[$i]['auto_load'] == TRUE) {
+          // Only load ontologies that are not already in the cv table.
+          $cv = chado_get_cv(['name' => $ontologies[$i]['cv_name']]);
+          $db = chado_get_db(['name' => $ontologies[$i]['db_name']]);
+          if (!$cv or !$db) {
+            print "Loading ontology: " . $ontologies[$i]['name'] . " ($obo_id)...\n";
+            $obo_importer = new OBOImporter();
+            $obo_importer->create(['obo_id' => $obo_id]);
+            $obo_importer->run();
+            $obo_importer->postRun();
+          }
+          else {
+            print "Ontology already loaded (skipping): " . $ontologies[$i]['name'] . "...\n";
+          }
+        }
+      }
+    */
+  }
+
+  /**
+   * Creates default content types.
+   */
+  protected function contentTypes() {
+    $this->generalContentTypes();
+    $this->genomicContentTypes();
+    $this->geneticContentTypes();
+    $this->germplasmContentTypes();
+    $this->expressionContentTypes();
+  }
+
+  /**
+   * Creates the "General" category of content types.
+   */
+  protected function generalContentTypes() {
+    // Create the 'Organism' entity type. This uses the obi:organism term.
+    $term = \Drupal::service('tripal.tripalTerm.manager')->getTerms([
+      'accession' => '0100026',
+      'vocabulary' => [
+        'namespace' => 'obi',
+        'idspace' => 'OBI',
+      ],
+    ]);
+
+    $organism = TripalEntityType::create([
+      'id' => 'organism',
+      'name' => 'organism',
+      'label' => 'Organism',
+      'term_id' => $term->getID(),
+      'help_text' => 'help',
+      'category' => 'General',
+    ]);
+    $organism->save();
+
+    // Create the 'Analysis' entity type. This uses the EDAM:analysis term.
+    $term = \Drupal::service('tripal.tripalTerm.manager')->getTerms([
+      'accession' => '2945',
+      'vocabulary' => [
+        'namespace' => 'EDAM',
+        'idspace' => 'operation',
+      ],
+    ]);
+
+    $analysis = TripalEntityType::create([
+      'id' => 2,
+      'name' => 'analysis',
+      'label' => 'Analysis',
+      'term_id' => $term->getID(),
+      'help_text' => 'help',
+      'category' => 'General',
+    ]);
+    $analysis->save();
+
+    // TODO: Create the 'Project' entity type.
+
+    // TODO: Create the 'Study' entity type.
+
+    // TODO: Create the 'Contact' entity type.
+
+    // TODO: Create the 'Publication' entity type.
+
+    // TODO: Create the 'Protocol' entity type.
+  }
+
+  /**
+   * Creates the "Genomic" category of content types.
+   */
+  protected function genomicContentTypes() {
+    // Create the 'Gene' entity type. This uses the sequence:gene term.
+    $term = \Drupal::service('tripal.tripalTerm.manager')->getTerms([
+      'accession' => '0000704',
+      'vocabulary' => [
+        'namespace' => 'sequence',
+        'idspace' => 'SO',
+      ],
+    ]);
+
+    $gene = TripalEntityType::create([
+      'id' => 'gene',
+      'name' => 'gene',
+      'label' => 'Gene',
+      'term_id' => $term->getID(),
+      'help_text' => 'help',
+      'category' => 'Genomic',
+    ]);
+    $gene->save();
+
+    // TODO: Create the 'mRNA' entity type.
+
+    // TODO: Create the 'Phylogenetic tree' entity type.
+
+    // TODO: Create the 'Physical Map' entity type.
+
+    // TODO: Create the 'DNA Library' entity type.
+
+    // TODO: Create the 'Genome Assembly' entity type.
+
+    // TODO: Create the 'Genome Annotation' entity type.
+
+    // TODO: Create the 'Genome Project' entity type.
+  }
+
+  /**
+   * Creates the "Genetic" category of content types.
+   */
+  protected function geneticContentTypes() {
+    // TODO: Create the 'Genetic Map' entity type.
+
+    // TODO: Create the 'QTL' entity type.
+
+    // TODO: Create the 'Sequence Variant' entity type.
+
+    // TODO: Create the 'Genetic Marker' entity type.
+
+    // TODO: Create the 'Heritable Phenotypic Marker' entity type.
+  }
+
+  /**
+   * Creates the "Germplasm/Breeding" category of content types.
+   */
+  protected function germplasmContentTypes() {
+    // TODO: Create the 'Phenotypic Trait' entity type.
+
+    // Create the 'Germplasm Accession' entity type.
+    $term = \Drupal::service('tripal.tripalTerm.manager')->getTerms([
+      'accession' => '0000044',
+      'vocabulary' => [
+        'namespace' => 'germplasm_ontology',
+        'idspace' => 'CO_010',
+      ],
+    ]);
+
+    $germplasm_accession = TripalEntityType::create([
+      'id' => 'germplasm_accession',
+      'name' => 'germplasm_accession',
+      'label' => 'Germplasm Accession',
+      'term_id' => $term->getID(),
+      'help_text' => 'help',
+      'category' => 'Germplasm/Breeding',
+    ]);
+    $germplasm_accession->save();
+
+    // TODO: Create the 'Breeding Cross' entity type.
+
+    // TODO: Create the 'Germplasm Variety' entity type.
+
+    // TODO: Create the 'Recombinant Inbred Line' entity type.
+  }
+
+  /**
+   * Creates the "Expression" category of content types.
+   */
+  protected function expressionContentTypes() {
+    // TODO: Create the 'biological sample' entity type.
+
+    // TODO: Create the 'Assay' entity type.
+
+    // TODO: Create the 'Array Design' entity type.
   }
 }

--- a/tripal_chado/src/legacyFunctions.php
+++ b/tripal_chado/src/legacyFunctions.php
@@ -60,9 +60,9 @@ function tripal_chado_drop_schema($schema, $job = NULL) {
  */
 function tripal_chado_prepare_chado($chado_schema = 'chado', $job = NULL) {
   $preparer = \Drupal::service('tripal_chado.chadoPreparer');
-  $preparer->setSchema($chado_schema);
   if ($job) {
     $preparer->setJob($job);
   }
+  $preparer->setSchema($chado_schema);
   $success = $preparer->prepare();
 }

--- a/tripal_chado/src/legacyFunctions.php
+++ b/tripal_chado/src/legacyFunctions.php
@@ -52,3 +52,17 @@ function tripal_chado_drop_schema($schema, $job = NULL) {
     \Drupal::logger('tripal_chado')->error("No schema was provided. Cannot drop.");
   }
 }
+
+/**
+ * Prepare Chado Schema
+ *
+ * @ingroup tripal_chado
+ */
+function tripal_chado_prepare_chado($chado_schema = 'chado', $job = NULL) {
+  $preparer = \Drupal::service('tripal_chado.chadoPreparer');
+  $preparer->setSchema($chado_schema);
+  if ($job) {
+    $preparer->setJob($job);
+  }
+  $success = $preparer->prepare();
+}

--- a/tripal_chado/tripal_chado.links.menu.yml
+++ b/tripal_chado/tripal_chado.links.menu.yml
@@ -13,3 +13,10 @@ tripal_chado.chado_install_form:
   description: 'Installs the Chado database tables, views, etc., inside the current Drupal database.'
   parent: tripal_chado.storage
   weight: 30
+
+tripal_chado.chado_prepare_form:
+  route_name: tripal_chado.chado_prepare_form
+  title: 'Prepare Chado'
+  description: 'Prepares Drupal to use Chado.'
+  parent: tripal_chado.storage
+  weight: 31

--- a/tripal_chado/tripal_chado.routing.yml
+++ b/tripal_chado/tripal_chado.routing.yml
@@ -15,3 +15,11 @@ tripal_chado.chado_install_form:
     _title: 'Chado Installation'
   requirements:
     _permission: 'administer tripal'
+
+tripal_chado.chado_prepare_form:
+  path: 'admin/tripal/storage/chado/prepare'
+  defaults:
+    _form: '\Drupal\tripal_chado\Form\ChadoPrepareForm'
+    _title: 'Chado Preparation'
+  requirements:
+    _permission: 'administer tripal'

--- a/tripal_chado/tripal_chado.services.yml
+++ b/tripal_chado/tripal_chado.services.yml
@@ -1,3 +1,5 @@
 services:
     tripal_chado.chadoInstaller:
         class: Drupal\tripal_chado\Services\chadoInstaller
+    tripal_chado.chadoPreparer:
+        class: Drupal\tripal_chado\Services\chadoInstaller

--- a/tripal_chado/tripal_chado.services.yml
+++ b/tripal_chado/tripal_chado.services.yml
@@ -2,4 +2,4 @@ services:
     tripal_chado.chadoInstaller:
         class: Drupal\tripal_chado\Services\chadoInstaller
     tripal_chado.chadoPreparer:
-        class: Drupal\tripal_chado\Services\chadoInstaller
+        class: Drupal\tripal_chado\Services\chadoPreparer


### PR DESCRIPTION
Issue tripal/t4d8#89 

**This PR includes the changes originally made by @par12005. This is the most recent collaborative code for this functionality. See notes on tripal/t4d8#107 for the previous testing comments.**

### Changes

- Create Chado Prepare Form
- Add routing and links for Chado Prepare Form
- Add Chado Preparer service
- Add ChadoPreparer class. This prepares the Chado installation by creating Tripal Vocab terms and Vocab Spaces. Also creates 4 entity types: organism, analysis, gene, and germplasm accession. More entity types should be created by the preparer in the future, but we will need to implement the OBOImporter class before this is possible.
- includes fixes to ensure Vocab/Term API is being used consistently.

### Notes

Each entity type currently only has the title and author fields. More fields should be imported based on the Chado tables that each type is associated with, but this will require the [tripal_create_bundle](https://github.com/tripal/tripal/blob/6ba91c7fd9cd43f2deae43d1b792f8fed387f41e/tripal/api/tripal.entities.api.inc#L447) function from the entities API to be implemented first.