### PR TITLE
Tripaldocker fixes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 # Run some PHPUnit tests
-name: Test Coverage
+name: Test Coverage on Drupal 9.0.x-dev
 
 # When do we want the tests to run?
 on: [push]
@@ -16,13 +16,23 @@ jobs:
       # Check out the repo
       - name: Checkout Repository
         uses: actions/checkout@v2
+      # Here we fully  build a docker using the current checked out code
+      # to ensure we have not broken the install/build process.
+      - name: Build the Docker
+        run: |
+          docker build --tag=tripaldocker:localdocker --build-arg drupalversion='9.0.x-dev' ./
       # Just spin up docker the good ol' fashion way.
-      - name: Spin up Docker
+      - name: Spin up Local Docker
         run: |
           docker run --publish=80:80 --name=tripaldocker -tid \
             --volume=`pwd`:/var/www/drupal8/web/modules/contrib/tripal \
-            tripalproject/tripaldocker:drupal9.0.x-dev
+            tripaldocker:localdocker
           docker exec tripaldocker service postgresql restart
+      # Now prepare the new docker container for running tests.
+      # We specifically do not have a `chado` named schema to test that
+      # an assumption hasn't been made here.
+      - name: Prep Local Docker for Tests
+        run: |
           docker exec tripaldocker drush cr
           docker exec tripaldocker drush trp-drop-chado --schema-name=chado
           docker exec tripaldocker drush trp-prep-tests

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -44,7 +44,7 @@ jobs:
           docker exec tripaldocker drush trp-prep-tests
       # Drupal 9.1.x needs prophecy-phpunit due to https://www.drupal.org/project/drupal/issues/3182653
       - name: Add prophecy-phpunit
-        if: ${{ matrix.drupalversion !== '9.0.x-dev' }}
+        if: ${{ matrix.drupalversion != '9.0.x-dev' }}
         run: |
           docker exec --workdir /var/www/drupal8 tripaldocker composer require phpspec/prophecy-phpunit
       # Runs the PHPUnit tests.

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,7 +13,7 @@ jobs:
     # PHP Targets
     strategy:
       matrix:
-        drupalversion: ['9.0.x-dev', '9.1.x-dev']
+        drupalversion: ['9.0.x-dev', '9.1.x-dev', '9.2.x-dev']
     # Give the builds names so we can tell them apart
     name: PHPUnit Drupal ${{ matrix.drupalversion }}
 
@@ -26,7 +26,7 @@ jobs:
       # to ensure we have not broken the install/build process.
       - name: Build the Docker
         run: |
-          docker build --tag=tripaldocker:localdocker --build-arg drupalversion='${{ matrix.drupalversion }}' tripaldocker/
+          docker build --tag=tripaldocker:localdocker --build-arg drupalversion='${{ matrix.drupalversion }}' ./
       # Just spin up docker the good ol' fashion way.
       - name: Spin up Local Docker
         run: |

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -44,7 +44,7 @@ jobs:
           docker exec tripaldocker drush trp-prep-tests
       # Drupal 9.1.x needs prophecy-phpunit due to https://www.drupal.org/project/drupal/issues/3182653
       - name: Add prophecy-phpunit
-        if: ${{ matrix.drupalversion == '9.1.x-dev' }}
+        if: ${{ matrix.drupalversion !== '9.0.x-dev' }}
         run: |
           docker exec --workdir /var/www/drupal8 tripaldocker composer require phpspec/prophecy-phpunit
       # Runs the PHPUnit tests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM php:7.3-apache-buster
 
 MAINTAINER Lacey-Anne Sanderson <laceyannesanderson@gmail.com>
 
-ARG drupalversion='9.0.x-dev'
+ARG drupalversion='9.1.x-dev'
 ARG modules='tripal tripal_chado'
 
 COPY . /app
@@ -135,7 +135,7 @@ RUN export COMPOSER_MEMORY_LIMIT=-1 \
   && composer create-project drupal/recommended-project:${drupalversion} drupal8 --stability dev --no-interaction \
   && cd drupal8 \
   && composer require --dev drupal/core-dev:${drupalversion} \
-  && composer require drush/drush \
+  && composer require drush/drush drupal/console:~1.0 \
   && composer up \
   && ls /var/www/drupal8/web/sites/default/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM php:7.3-apache-buster
 
 MAINTAINER Lacey-Anne Sanderson <laceyannesanderson@gmail.com>
 
-ARG drupalversion='8.9.x-dev'
+ARG drupalversion='9.0.x-dev'
+ARG modules='tripal tripal_chado'
 
 COPY . /app
 
@@ -41,7 +42,7 @@ USER root
 
 ## Adjust PostgreSQL configuration so that remote connections to the
 ## database are possible.
-RUN mv /app/default_files/postgresql/pg_hba.conf /etc/postgresql/11/main/pg_hba.conf
+RUN mv /app/tripaldocker/default_files/postgresql/pg_hba.conf /etc/postgresql/11/main/pg_hba.conf
 
 ## And add ``listen_addresses`` to ``/etc/postgresql/11/main/postgresql.conf``
 RUN echo "listen_addresses='*'" >> /etc/postgresql/11/main/postgresql.conf \
@@ -124,8 +125,8 @@ ENV BROWSER_OUTPUT_DIRECTORY=/var/www/drupal8/web/sites/default/files/simpletest
 
 ## Install composer and Drush.
 WORKDIR /var/www
-RUN chmod a+x /app/init_scripts/composer-init.sh \
-  && /app/init_scripts/composer-init.sh \
+RUN chmod a+x /app/tripaldocker/init_scripts/composer-init.sh \
+  && /app/tripaldocker/init_scripts/composer-init.sh \
   && vendor/bin/drush --version
 
 ## Use composer to install Drupal.
@@ -164,18 +165,18 @@ WORKDIR /var/www/drupal8
 RUN service apache2 restart \
   && service postgresql restart \
   && sleep 30 \
-  && composer require tripal/tripal \
+  && cp -R /app /var/www/drupal8/web/modules/tripal \
   && composer require drupal/devel \
-  && vendor/bin/drush en devel tripal tripal_chado -y \
+  && vendor/bin/drush en devel tripal ${modules} -y \
   && vendor/bin/drush trp-install-chado
 
 ############# Scripts #########################################################
 
 ## Configuration files & Activation script
-RUN mv /app/init_scripts/supervisord.conf /etc/supervisord.conf \
-  && mv /app/default_files/000-default.conf /etc/apache2/sites-available/000-default.conf \
+RUN mv /app/tripaldocker/init_scripts/supervisord.conf /etc/supervisord.conf \
+  && mv /app/tripaldocker/default_files/000-default.conf /etc/apache2/sites-available/000-default.conf \
   && echo "\$settings["trusted_host_patterns"] = [ '^localhost$', '^127\.0\.0\.1$' ];" >> /var/www/drupal8/web/sites/default/settings.php \
-  && mv /app/init_scripts/init.sh /usr/bin/init.sh \
+  && mv /app/tripaldocker/init_scripts/init.sh /usr/bin/init.sh \
   && chmod +x /usr/bin/init.sh
 
 ## Make global commands.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,19 @@ This project acts as the home of Tripal 4 development. Once Tripal 4 is stable, 
   - [Developer Guide](https://tripal4.readthedocs.io/en/latest/dev_guide.html)
   - [Contribution Guide](https://tripal4.readthedocs.io/en/latest/contributing.html)
 
+## Tripal Docker
+
+Tripal Docker is currently focused on Development and Unit Testing. There will be a production focused Tripal Docker soon and if you're interested in helping or providing tips -please join us on our Slack channel!
+
+For more information about how to use our fully functional development docker, see [our documentation on ReadtheDocs!](https://tripal4.readthedocs.io/en/latest/install/docker.html)
+
 # Upgrade Progress
 
 ### How to get involved!
 
 This upgrade to Drupal 9 is a community effort. As such, we NEED YOUR HELP!
 
-  - To get involved, please join [our Tripal Slack](http://tripal.info/join/slack) and comment in the #core-dev channel. 
+  - To get involved, please join [our Tripal Slack](http://tripal.info/join/slack) and comment in the #core-dev channel.
     - Alternatively, feel free to contact Lacey-Anne Sanderson through Slack direct message.
     - We can use help both with programming, documentation, outreach and welcome all individuals from all backgrounds!
   - We prefer [automated testing](https://tripal4.readthedocs.io/en/latest/dev_guide/testing.html) for all Pull Requests (PRs) and are happy to guide you through the process!

--- a/docs/install/docker.rst
+++ b/docs/install/docker.rst
@@ -8,13 +8,13 @@ Software Stack
 
 Currently we have the following installed:
  - Debian Buster(10)
- - PHP 7.3.25 with extensions needed for Drupal (Memory limit 1028M)
+ - PHP 7.3.32 with extensions needed for Drupal (Memory limit 1028M)
  - Apache 2.4.38
- - PostgreSQL 11.9 (Debian 11.9-0+deb10u1)
- - Composer 2.0.7
+ - PostgreSQL 11.13 (Debian 11.13-0+deb10u1)
+ - Composer 2.1.11
  - Drupal Console 1.9.7
- - Drush 10.3.6
- - Drupal 8.9.10  (8.x-dev) downloaded using composer.
+ - Drush 10.6.1
+ - Drupal 9.1.13 downloaded using composer (or as specified by drupalversion argument).
 
 Quickstart
 ----------
@@ -82,8 +82,10 @@ Usage
 Detailed Setup for Core Development
 ------------------------------------
 
-1. `Install Docker <https://docs.docker.com/get-docker>`_ for your system.
+Using Latest tagged version
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1. `Install Docker <https://docs.docker.com/get-docker>`_ for your system.
 
 2. Clone the most recent version of Tripal 4 keeping track of where you cloned it.
 
@@ -127,6 +129,43 @@ Detailed Setup for Core Development
 
 **Furthermore, the --volume part of the run command ensures any changes made in your local directory are automatically copied into the docker container so you can live edit your website.**
 
+Testing install for a specific branch or update the docker image.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following instructions will show you how to create the TripalDocker image from the code existing locally. **This should only be needed if you have made changes to Tripal 4 that impact the installation process, you have created a new module and/or if you have created a new Tripal release. Otherwise, you should be able to use the image from docker hub accessed via the docker pull command.**
+
+First if you do not have a local copy of the t4d8 repository, you can use the following instructions to get one. If you do have a copy already, make sure it is up to date and contains the changes you would like to test.
+
+.. code-block:: bash
+
+  mkdir ~/Dockers
+  cd ~/Dockers
+  git clone https://github.com/tripal/t4d8
+
+Next, you use the `docker build <https://docs.docker.com/engine/reference/commandline/build/>`_ command to create an image from the existing TripalDocker Dockerfile. Since we are testing Tripal 4 on multiple versions of Drupal, you can set the Drupal major version using the drupalversion argument as shown below. The version of Drupal used for the latest tag is the default value of the argument in the Dockerfile.
+
+.. code-block:: bash
+
+  cd t4d8
+  docker build --tag=tripalproject/tripaldocker:drupal9.1.x-dev --build-arg drupalversion='9.1.x-dev' ./
+
+This process will take a fair amount of time as it completely installs Drupal, Tripal and PostgreSQL. You will see a large amount of red text but hopefully not any errors. You should always test the image by running it before pushing it up to docker hub!
+
+.. note::
+
+  Make sure the drupal version specified in the tag matches the build argument. The value of ``drupalversion`` must match one of the available tags on `Packagist drupal/core <https://packagist.org/packages/drupal/core>`_.
+
+.. warning::
+
+  If your new changes to Tripal 4 break install, you will experience one of the following depending on the type of error:
+
+  1. The build command executed above will not complete without errors.
+  2. When you run the image after it is built including starting PostgreSQL, you will not have a functional Tripal site.
+
+.. note::
+
+  To **test your image**, execute any of the ``docker run`` commands documented above making sure to also start PostgreSQL (i.e. ``docker exec t4d8 service postgresql restart``). At this point you will already have Drupal, Tripal and Chado installed. It is recommended to also do a quick test of core functionality which may have been impacted by any recent changes.
+
 Troubleshooting
 ---------------
 
@@ -134,7 +173,7 @@ The provided host name is not valid for this server.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 On my web browser, I got the message "The provided host name is not valid for this server".
 
-**Solution:** It is most likely because you tried to access the site through a URL different from ``localhost`` or ``127.0.0.1``. For instance, if you run docker on a server and want to access your d8t4 site through that server name, you will have to edit the settings.php file inside the docker (at the time writting this, it would be everytime you (re)start the docker) and change the last line containing the parameter ``$settings[trusted_host_patterns]``:
+**Solution:** It is most likely because you tried to access the site through a URL different from ``localhost`` or ``127.0.0.1``. For instance, if you run docker on a server and want to access your d8t4 site through that server name, you will have to edit the settings.php file inside the docker (at the time writing this, it would be every time you (re)start the docker) and change the last line containing the parameter ``$settings[trusted_host_patterns]``:
 
 .. code::
 
@@ -158,40 +197,3 @@ As Tripal 4 is currently under rapid development, this could be due to not using
   docker pull tripalproject/tripaldocker:latest
 
 At this point, you can follow up with the appropriate ``docker run`` command. If your run command mounts the current directory through the ``--volume`` parameter then make sure you are in a copy of the t4d8 repository on the main branch with the most recent changes pulled.
-
-Testing install for a specific branch or update the docker image.
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The following instructions will show you how to create the TripalDocker image from the code existing locally. **This should only be needed if you have made changes to Tripal 4 that impact the installation process and/or if you have created a new Tripal release. Otherwise, you should be able to use the image from docker hub accessed via the docker pull command.**
-
-First if you do not have a local copy of the t4d8 repository, you can use the following instructions to get one. If you do have a copy already, make sure it is up to date and contains the changes you would like to test.
-
-.. code-block:: bash
-
-  mkdir ~/Dockers
-  cd ~/Dockers
-  git clone https://github.com/tripal/t4d8
-
-Next, you use the `docker build <https://docs.docker.com/engine/reference/commandline/build/>`_ command to create an image from the existing TripalDocker Dockerfile. Since we are testing Tripal 4 on multiple versions of Drupal, you can set the Drupal major version using the drupalversion argument as shown below. The version of Drupal used for the latest tag is the default value of the argument in the Dockerfile.
-
-.. code-block:: bash
-
-  cd t4d8
-  docker build --tag=tripalproject/tripaldocker:drupal9.0.x-dev --build-arg drupalversion='9.0.x' tripaldocker/
-
-This process will take a fair amount of time as it completely installs Drupal, Tripal and PostgreSQL. You will see a large amount of red text but hopefully not any errors. You should always test the image by running it before pushing it up to docker hub!
-
-.. note::
-
-  Make sure the drupal version specified in the tag matches the build argument. The value of ``drupalversion`` must match one of the available tags on `Packagist drupal/core <https://packagist.org/packages/drupal/core>`_.
-
-.. warning::
-
-  If your new changes to Tripal 4 break install, you will experience one of the following depending on the type of error:
-
-  1. The build command executed above will not complete without errors.
-  2. When you run the image after it is built including starting PostgreSQL, you will not have a functional Tripal site.
-
-.. note::
-
-  To **test your image**, execute any of the ``docker run`` commands documented above making sure to also start PostgreSQL (i.e. ``docker exec t4d8 service postgresql restart``). At this point you will already have Drupal, Tripal and Chado installed. It is recommended to also do a quick test of core functionality which may have been impacted by any recent changes.

--- a/tripaldocker/README.md
+++ b/tripaldocker/README.md
@@ -1,54 +1,6 @@
-# Tripal Docker
+Tripal Docker
+==================
 
-Tripal Docker is currently focused on Development and Unit Testing. There will be a production focused Tripal Docker soon.
+Tripal Docker is currently focused on Development and Unit Testing. There will be a production focused Tripal Docker soon and if you're interested in helping or providing tips -please join us on our Slack channel!
 
-## Software Stack
-
-Currently we have the following installed:
- - Debian Buster(10)
- - PHP 7.3.25 with extensions needed for Drupal (Memory limit 1028M)
- - Apache 2.4.38
- - PostgreSQL 11.9 (Debian 11.9-0+deb10u1)
- - Composer 2.0.7
- - Drupal Console 1.9.7
- - Drush 10.3.6
- - Drupal 8.9.10  (8.x-dev) downloaded using composer.
-
-## Setup
-
-1. Run the image in the background mapping it's web server to your port 9000.
-
-    a) Stand-alone container for testing or demonstration.
-    ```
-    docker run --publish=9000:80 --name=t4d8 -tid tripalproject/tripaldocker:latest
-    ```
-    b) Development container with current directory mounted within the container for easy edits. Change my_module with the name of yours.
-    ```
-    docker run --publish=9000:80 --name=t4d8 -tid --volume=`pwd`:/var/www/drupal8/web/modules/my_module tripalproject/tripaldocker:latest
-    ```
-
-2. Start the PostgreSQL database.
-```
-docker exec t4d8 service postgresql start
-```
-
-3. Navigate to http://localhost:9000 to your fully function site. Drupal was installed using the standard profile during image creation. The administration user is drupaladmin:some_admin_password.
-
-
-## Usage
- - Run Drupal Core PHP Unit Tests:
-     ```
-     docker exec t4d8 phpunit --configuration core core/modules/simpletest/tests
-     ```
- - Run Drupal Console to generate code for your module!
-     ```
-     docker exec t4d8 drupal generate:module
-     ```
- - Run Drush to rebuild the cache
-     ```
-     docker exec t4d8 drush cr
-     ```
- - Run Composer to upgrade Drupal
-     ```
-     docker exec t4d8 composer up
-     ```
+For more information about how to use our fully functional development docker, see [our documentation on ReadtheDocs!](https://tripal4.readthedocs.io/en/latest/install/docker.html)


### PR DESCRIPTION
This PR adds the following fixes to TripalDocker:

- Move dockerfile to the root so it has access to all modules
- Ensure tripaldocker uses the local code within the docker image
- update docker instructions
- install drupal console
- Adds 9.2.x to automated testing workflow

