### PR TITLE
Autobuild docker image on main branch only

### DIFF
--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -8,9 +8,16 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-      - name: Build image
-        run: |
-          docker build --tag=tripalproject/tripaldocker:drupal9.1.x-dev --build-arg drupalversion='9.1.x-dev' ./ \
-          && docker images
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: tripalproject/tripaldocker:test
+          build-args:
+            - drupalversion: '9.1.x-dev'

--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           push: true
           tags: tripalproject/tripaldocker:test
-          build-args: "drupalversion='9.1.x-dev'"
+          build-args: "drupalversion=9.1.x-dev"

--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -5,8 +5,11 @@ on:
       - autobuild-image
 jobs:
   push_to_registry:
-    name: Build and publish
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        drupalversion: ['9.0.x-dev', '9.1.x-dev', '9.2.x-dev']
+    name: Docker Build (Drupal ${{ matrix.drupalversion }})
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
@@ -18,5 +21,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: tripalproject/tripaldocker:test
-          build-args: "drupalversion=9.1.x-dev"
+          tags: tripalproject/tripaldocker:${{ matrix.drupalversion }}-test
+          build-args: "drupalversion=${{ matrix.drupalversion }}"

--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -1,0 +1,16 @@
+name: Build and Publish Docker image
+on:
+  push:
+    branches:
+      - autobuild-image
+jobs:
+  push_to_registry:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Build image
+        run: |
+          docker build --tag=tripalproject/tripaldocker:drupal9.1.x-dev --build-arg drupalversion='9.1.x-dev' ./ \
+          && docker images

--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -19,5 +19,4 @@ jobs:
         with:
           push: true
           tags: tripalproject/tripaldocker:test
-          build-args:
-            - drupalversion: '9.1.x-dev'
+          build-args: "drupalversion='9.1.x-dev'"

--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -23,5 +23,5 @@ jobs:
           push: true
           tags: |
             tripalproject/tripaldocker:drupal${{ matrix.drupalversion }}-test
-            ${{ (matrix.drupalversion == '9.1.x-dev' && 'tripalproject/tripaldocker:latest-test' ) }}
+            ${{ (matrix.drupalversion == '9.1.x-dev' && 'tripalproject/tripaldocker:latest-test' ) || '' }}
           build-args: "drupalversion=${{ matrix.drupalversion }}"

--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         drupalversion: ['9.0.x-dev', '9.1.x-dev', '9.2.x-dev']
-    name: Docker Build (Drupal ${{ matrix.drupalversion }})
+    name: Docker Build (drupal${{ matrix.drupalversion }})
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
@@ -21,5 +21,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: tripalproject/tripaldocker:${{ matrix.drupalversion }}-test
+          tags: |
+            tripalproject/tripaldocker:drupal${{ matrix.drupalversion }}-test
+            ${{ (matrix.drupalversion == '9.1.x-dev' && 'tripalproject/tripaldocker:latest-test' ) }}
           build-args: "drupalversion=${{ matrix.drupalversion }}"

--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -2,7 +2,7 @@ name: Build and Publish Docker image
 on:
   push:
     branches:
-      - autobuild-image
+      - 9.x-4.x
 jobs:
   push_to_registry:
     runs-on: ubuntu-latest
@@ -22,6 +22,6 @@ jobs:
         with:
           push: true
           tags: |
-            tripalproject/tripaldocker:drupal${{ matrix.drupalversion }}-test
-            ${{ (matrix.drupalversion == '9.1.x-dev' && 'tripalproject/tripaldocker:latest-test' ) || '' }}
+            tripalproject/tripaldocker:drupal${{ matrix.drupalversion }}
+            ${{ (matrix.drupalversion == '9.1.x-dev' && 'tripalproject/tripaldocker:latest' ) || '' }}
           build-args: "drupalversion=${{ matrix.drupalversion }}"


### PR DESCRIPTION
This PR adds a github workflow to automate making docker images and pushing them to our Tripaldocker on docker hub: https://hub.docker.com/repository/docker/tripalproject/tripaldocker/general 

I tested this extensively with test tags which have since been deleted and then the last commit moves it to the current main branch. This is ready to go just waiting on required tests passing.