### PR TITLE
Stop specific phpunit deprecation notices that Drupal or Symphony cause.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,8 @@
     <ini name="error_reporting" value="32767"/>
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
+    <!-- Stop specific phpunit deprecation notices that Drupal or Symphony cause. -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
     <env name="SIMPLETEST_BASE_URL" value="http://localhost"/>
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->


### PR DESCRIPTION
Fixes the following PHPunit deprecation in Drupal core:

```
  1x: The "Drupal\Tests\Listeners\DrupalListener" class implements "PHPUnit\Framework\TestListener" that is deprecated.
    1x in DrupalListener::endTest from Drupal\Tests\Listeners
```