### PR TITLE
Upgraded db_query deprecated calls for the tripalImporterReviewed branch

### DIFF
--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -234,7 +234,8 @@ class OBOImporter extends TripalImporter {
 
     // get a list of db from chado for user to choose
     $sql = "SELECT * FROM tripal_cv_obo ORDER BY name";
-    $results = db_query($sql);
+    $connection = \Drupal::database();
+    $results = $connection->query($sql);
 
     $obos = [];
     $obos[] = 'Select a Vocabulary';
@@ -2652,7 +2653,8 @@ class OBOImporter extends TripalImporter {
       // Refresh the OBO select list
       // get a list of db from chado for user to choose
       $sql = "SELECT * FROM tripal_cv_obo ORDER BY name";
-      $results = db_query($sql);
+      $connection = \Drupal::database();
+      $results = $connection->query($sql);
 
       $obos = [];
       $obos[] = 'Select a Vocabulary';

--- a/tripal_chado/src/api/tripal_chado.custom_tables.api.inc
+++ b/tripal_chado/src/api/tripal_chado.custom_tables.api.inc
@@ -39,7 +39,8 @@ function chado_edit_custom_table($table_id, $table_name, $schema, $skip_if_exist
 
         // Get the current custom table record.
         $sql = "SELECT * FROM {tripal_custom_tables} WHERE table_id = :table_id";
-        $results = db_query($sql, [':table_id' => $table_id]);
+        $connection = \Drupal::database();
+        $results = $conection->query($sql, [':table_id' => $table_id]);
         $custom_table = $results->fetchObject();
 
         // Check if the table is suitable for editing (not mview, doesn't exist in tripal_custom_tables table).

--- a/tripal_chado/src/api/tripal_chado.custom_tables.api.inc
+++ b/tripal_chado/src/api/tripal_chado.custom_tables.api.inc
@@ -40,7 +40,7 @@ function chado_edit_custom_table($table_id, $table_name, $schema, $skip_if_exist
         // Get the current custom table record.
         $sql = "SELECT * FROM {tripal_custom_tables} WHERE table_id = :table_id";
         $connection = \Drupal::database();
-        $results = $conection->query($sql, [':table_id' => $table_id]);
+        $results = $connection->query($sql, [':table_id' => $table_id]);
         $custom_table = $results->fetchObject();
 
         // Check if the table is suitable for editing (not mview, doesn't exist in tripal_custom_tables table).

--- a/tripal_chado/src/api/tripal_chado.mapping.api.inc
+++ b/tripal_chado/src/api/tripal_chado.mapping.api.inc
@@ -82,7 +82,6 @@ function tripal_chado_map_cvterms() {
             "SELECT mapping_id
              FROM chado_cvterm_mapping
              WHERE cvterm_id = :cvterm_id";
-          $connection = \Drupal::database();
           $mapped = $connection->query($check_sql, [':cvterm_id' => $cvterm_id])->fetchField();
           // If mapping does not exist and a table name matches the term name, add it
           if (!$mapped && chado_table_exists($name)) {

--- a/tripal_chado/src/api/tripal_chado.mapping.api.inc
+++ b/tripal_chado/src/api/tripal_chado.mapping.api.inc
@@ -47,8 +47,9 @@ function tripal_chado_map_cvterms() {
        (SELECT namespace FROM tripal_vocab TV WHERE id = TM.idspace_id),
         accession,
         name
-     FROM tripal_term TM";    
-    $results = db_query($sql);
+     FROM tripal_term TM"; 
+    $connection = \Drupal::database();   
+    $results = $connection->query($sql);
     while ($tripal_term = $results->fetchObject()) {
       $voc = $tripal_term->vocabulary;
       $accession = $tripal_term->accession;
@@ -81,7 +82,8 @@ function tripal_chado_map_cvterms() {
             "SELECT mapping_id
              FROM chado_cvterm_mapping
              WHERE cvterm_id = :cvterm_id";
-          $mapped = db_query($check_sql, [':cvterm_id' => $cvterm_id])->fetchField();
+          $connection = \Drupal::database();
+          $mapped = $connection->query($check_sql, [':cvterm_id' => $cvterm_id])->fetchField();
           // If mapping does not exist and a table name matches the term name, add it
           if (!$mapped && chado_table_exists($name)) {
             print "Adding mapped tripal term: $name\n";

--- a/tripal_chado/src/api/tripal_chado.mviews.api.inc
+++ b/tripal_chado/src/api/tripal_chado.mviews.api.inc
@@ -177,7 +177,8 @@ function chado_edit_mview($mview_id, $name, $modulename, $mv_table, $mv_specs,
     // just save the updated SQL.
     $create_table = 1;
     $sql = "SELECT * FROM {tripal_mviews} WHERE mview_id = :mview_id";
-    $results = db_query($sql, [':mview_id' => $mview_id]);
+    $connection = \Drupal::database();
+    $results = $connection->query($sql, [':mview_id' => $mview_id]);
     $mview = $results->fetchObject();
     if ($mview->mv_schema == $mv_schema and $mview->mv_table == $mv_table) {
       chado_create_custom_table($mv_table, $schema_arr, 0, $record->mview_id);
@@ -227,7 +228,8 @@ function chado_edit_mview($mview_id, $name, $modulename, $mv_table, $mv_specs,
 function chado_get_mview_id($view_name) {
   if (db_table_exists('tripal_mviews')) {
     $sql = "SELECT * FROM {tripal_mviews} WHERE name = :name";
-    $results = db_query($sql, [':name' => $view_name]);
+    $connection = \Drupal::database();
+    $results = $connection->query($sql, [':name' => $view_name]);
     $mview = $results->fetchObject();
     if ($mview) {
       return $mview->mview_id;
@@ -248,7 +250,8 @@ function chado_get_mview_id($view_name) {
 function chado_get_mview_table_names() {
 
   $sql = "SELECT name FROM {tripal_mviews}";
-  $resource = db_query($sql);
+  $connection = \Drupal::database();
+  $resource = $connection->query($sql);
 
   $tables = [];
   foreach ($resource as $r) {
@@ -278,7 +281,8 @@ function chado_refresh_mview($mview_id) {
 
   // Get this mview details.
   $sql = "SELECT * FROM {tripal_mviews} WHERE mview_id = :mview_id";
-  $results = db_query($sql, [':mview_id' => $mview_id]);
+  $connection = \Drupal::database();
+  $results = $connection->query($sql, [':mview_id' => $mview_id]);
   $mview = $results->fetchObject();
 
   // Add a job to populate the mview.
@@ -337,13 +341,14 @@ function chado_delete_mview($mview_id) {
 
     // Get this mview details.
     $sql = "SELECT * FROM {tripal_mviews} WHERE mview_id = :mview_id";
-    $results = db_query($sql, [':mview_id' => $mview_id]);
+    $connection = \Drupal::database();
+    $results = $connection->query($sql, [':mview_id' => $mview_id]);
     $mview = $results->fetchObject();
 
     // If op is to delete then do so.
     // Remove the mview from the tripal_mviews table.
     $sql = "DELETE FROM {tripal_mviews} WHERE mview_id = $mview_id";
-    db_query($sql);
+    $connection->query($sql);
 
     // Does the table already exist?
     $mview_exists = chado_table_exists($mview->mv_table);
@@ -395,7 +400,8 @@ function chado_delete_mview($mview_id) {
  */
 function chado_populate_mview($mview_id) {
   $sql = "SELECT * FROM {tripal_mviews} WHERE mview_id = :mview_id ";
-  $results = db_query($sql, [':mview_id' => $mview_id]);
+  $connection = \Drupal::database();
+  $results = $connection->query($sql, [':mview_id' => $mview_id]);
   $mview = $results->fetchObject();
   if ($mview) {
     // Execute the query inside a transaction so that it doesn't destroy 


### PR DESCRIPTION
@laceysanderson I began ranning some UI tests on the importer reviewed branch and I came across some db_query calls (currently deprecated now in D9) so I've tried to update them using the connection->query functions instead. This is the PR to add those fixes.