### PR TITLE
Importer - 3 - Removed deprecated Unicode::strlen back to mb_strlen function

### DIFF
--- a/tripal_chado/includes/TripalImporter/OBOImporter.inc
+++ b/tripal_chado/includes/TripalImporter/OBOImporter.inc
@@ -2125,7 +2125,7 @@ class OBOImporter extends TripalImporter {
     $fh = fopen($obo_file, 'r');
     while ($line = fgets($fh)) {
       $line_num++;
-      $size = \Drupal\Component\Utility\Unicode::strlen($line);
+      $size = mb_strlen($line);
       $num_read += $size;
       $line = trim($line);
       $this->setItemsHandled($num_read);


### PR DESCRIPTION
Simple but critical fix for string length checks of a deprecated function required for importers to be compatible with D9