### PR TITLE
Importer - 8 - tripal importer reviewed gff3 d9 fixes - file_load deprecated functions replaced

### DIFF
--- a/tripal/includes/TripalImporter.inc
+++ b/tripal/includes/TripalImporter.inc
@@ -361,7 +361,7 @@ class TripalImporter {
         if (preg_match('/\|/', $file_details['fid'])) {
           $fids = explode('|', $file_details['fid']);
           foreach ($fids as $fid) {
-            $file = file_load($fid);
+            $file = \Drupal\file\Entity\File::load($fid);
             $arguments['files'][] = [
               // 'file_path' => drupal_realpath($file->uri), // old
               'file_path' => \Drupal::service('file_system')->realpath($file->getFileUri()),

--- a/tripal/includes/TripalImporter.inc
+++ b/tripal/includes/TripalImporter.inc
@@ -373,7 +373,7 @@ class TripalImporter {
         // Handle a single file.
         else {
           $fid = $file_details['fid'];
-          $file = file_load($fid);
+          $file = \Drupal\file\Entity\File::load($fid);
           $arguments['files'][] = [
             // 'file_path' => drupal_realpath($file->uri), // old
             'file_path' => \Drupal::service('file_system')->realpath($file->getFileUri()),

--- a/tripal_chado/src/api/tripal_chado.organism.api.inc
+++ b/tripal_chado/src/api/tripal_chado.organism.api.inc
@@ -254,7 +254,7 @@ function chado_get_organism_image_url($organism) {
     ->execute()
     ->fetchField();
   if ($fid) {
-    $file = file_load($fid);
+    $file = \Drupal\file\Entity\File::load($fid);
     return file_create_url($file->uri);
   }
 


### PR DESCRIPTION
During my test compile of the Tripal Importer Reviewed branch plus the "Importer" open PR branches, I found some other deprecation issues particularly with the file_load function which is no longer available for use in D9. It's been replaced with the recommended replacement function.

By the time you merge this into Tripal Importer Reviewed branch - a test run of Sequence Onotology import, GFF3 Citrus and FASTA Citrus files should work.

The process of doing the import remains for the most part unchanged in terms of instructions (reference documentation: https://tripal.readthedocs.io/en/latest/user_guide/example_genomics/genomes_genes.html) 