### PR TITLE
ChadoIdSpace, ChadoVocabulary and TripalTerm classes are now fully implemented and tested

### DIFF
--- a/tripal/src/TripalVocabTerms/Interfaces/TripalIdSpaceInterface.php
+++ b/tripal/src/TripalVocabTerms/Interfaces/TripalIdSpaceInterface.php
@@ -115,13 +115,15 @@ interface TripalIdSpaceInterface extends TripalCollectionPluginInterface {
    * given or false to not update this existing term's parent. If this term
    * is new this has no effect. The default is false.
    *
+   * @param TripalTerm $term
+   *   The TripalTerm object to save.
    * @param array $options
    *   The options array.
    *
    * @return bool
    *   True on success or false otherwise.
    */
-  public function saveTerm($term, $options);
+  public function saveTerm(TripalTerm $term, $options);
     
 
   /**

--- a/tripal/src/TripalVocabTerms/Interfaces/TripalIdSpaceInterface.php
+++ b/tripal/src/TripalVocabTerms/Interfaces/TripalIdSpaceInterface.php
@@ -31,30 +31,50 @@ interface TripalIdSpaceInterface extends TripalCollectionPluginInterface {
    *   The given term or NULL.
    *
    * @return array
-   *   An array of Drupal\tripal\TripalVocabTerms\TripalTerm children objects.
+   *   An array of children terms where each entry is a tuples and the 
+   *   first element of the tuple is a Drupal\tripal\TripalVocabTerms\TripalTerm 
+   *   child object and the second is the a
+   *   Drupal\tripal\TripalVocabTerms\TripalTerm relationship type term.
    */
   public function getChildren($parent = NULL);
 
   /**
-   * Returns the term in this id space with the given accession. If no such term
-   * exists then NULL is returned.
+   * Returns the term in this id space with the given accession. 
+   * 
+   * If no such term exists then NULL is returned.
+   * 
+   * The given options array has the following recognized keys:
+   *
+   * includes(array): A list of attribute names to include with the term
+   *   object. The attribute names can be: 'parents', 'altIds', 'synonyms'
+   *   'properties'. If the key is missing then all attributes will
+   *   be loaded. If present but empty then only basic attributes will
+   *   be loaded (e.g. name, definition, etc.). The purpose of this
+   *   attribute is to save time loading when not all attributes are 
+   *   needed.
    *
    * @param string $accession
    *   The accession.
+   *   
+   * @param array|NULL $options
+   *   The options array.
    *
    * @return Drupal\tripal\TripalVocabTerms\TripalTerm|NULL
    *   The term or NULL.
    */
-  public function getTerm($accession);
+  public function getTerm($accession, $options = []);
 
   /**
-   * Returns the terms in this id space whose names match the given name with
-   * the given options array.
+   * Returns terms whose names match the given arguments.
+   * 
+   * Term can be matched on their name or synonyms.  If the provided $name
+   * argument matches both the name and a synonym of the same term then
+   * both matches will be returned.
    *
    * The given options array has the following recognized keys:
    *
    * exact(boolean): True to only include exact matches else false to include
-   * all substring matches. The default is false.
+   *   all substring matches. The default is false.
    *
    * @param string $name
    *   The name.
@@ -63,9 +83,14 @@ interface TripalIdSpaceInterface extends TripalCollectionPluginInterface {
    *   The options array.
    *
    * @return array
-   *   Array of matching Drupal\tripal\TripalVocabTerms\TripalTerm instances.
+   *   Associative array of matching terms. The first-level key is the full 
+   *   string that matched the provided name. The second-level key is the term ID
+   *   (e.g. GO:0044708) and the value is an the  
+   *   Drupal\tripal\TripalVocabTerms\TripalTerm term. These terms will only have
+   *   these attributes loaded: name, definition, accession, idSpace and
+   *   vocabulary.
    */
-  public function getTerms($name, $options);
+  public function getTerms($name, $options = []);
 
   /**
    * Sets the default vocabulary of this id space to the given vocabulary name.
@@ -117,13 +142,14 @@ interface TripalIdSpaceInterface extends TripalCollectionPluginInterface {
    *
    * @param TripalTerm $term
    *   The TripalTerm object to save.
+   *   
    * @param array $options
-   *   The options array.
+   *   An associative array of options.
    *
    * @return bool
    *   True on success or false otherwise.
    */
-  public function saveTerm(TripalTerm $term, $options);
+  public function saveTerm(TripalTerm $term, array $options = []);
     
 
   /**

--- a/tripal/tests/src/Functional/TripalDBX/ConnectionTest.php
+++ b/tripal/tests/src/Functional/TripalDBX/ConnectionTest.php
@@ -402,7 +402,7 @@ class ConnectionTest extends KernelTestBase {
    * @cover ::prefixTables
    */
   public function testSchemaNameChangeImpacts() {
-    $drupal_prefix = $this->testhelper_get_drupal_prefix();
+    $drupal_prefix = $this->get_drupal_prefix();
 
     $dbmock = $this->getConnectionMock('first');
     // Manages fake versions. First schema would be 42 and next 806.
@@ -468,7 +468,7 @@ class ConnectionTest extends KernelTestBase {
    * @cover ::addExtraSchema
    */
   public function testAddExtraSchemaNoSchema() {
-    $drupal_prefix = $this->testhelper_get_drupal_prefix();
+    $drupal_prefix = $this->get_drupal_prefix();
     $dbmock = $this->getConnectionMock();
 
     $this->expectException(\Drupal\tripal\TripalDBX\Exceptions\ConnectionException::class);
@@ -482,7 +482,7 @@ class ConnectionTest extends KernelTestBase {
    * @cover ::setExtraSchema
    */
   public function testSetExtraSchemaZero() {
-    $drupal_prefix = $this->testhelper_get_drupal_prefix();
+    $drupal_prefix = $this->get_drupal_prefix();
     $dbmock = $this->getConnectionMock();
 
     $this->expectException(\Drupal\tripal\TripalDBX\Exceptions\ConnectionException::class);
@@ -496,7 +496,7 @@ class ConnectionTest extends KernelTestBase {
    * @cover ::setExtraSchema
    */
   public function testSetExtraSchemaOne() {
-    $drupal_prefix = $this->testhelper_get_drupal_prefix();
+    $drupal_prefix = $this->get_drupal_prefix();
     $dbmock = $this->getConnectionMock();
 
     $this->expectException(\Drupal\tripal\TripalDBX\Exceptions\ConnectionException::class);
@@ -510,7 +510,7 @@ class ConnectionTest extends KernelTestBase {
    * @cover ::prefixTables
    */
   public function testPrefixNoSchema() {
-    $drupal_prefix = $this->testhelper_get_drupal_prefix();
+    $drupal_prefix = $this->get_drupal_prefix();
     $dbmock = $this->getConnectionMock();
 
     $this->markTestSkipped('Currently skipping this test as an exception is not thrown as expected. This is likely due to changes in the Connection::prefixTables() method during migrations to Tripal DBX.');
@@ -541,7 +541,7 @@ class ConnectionTest extends KernelTestBase {
    * @cover ::prefixTables
    */
   public function testPrefixNoExtraSchema() {
-    $drupal_prefix = $this->testhelper_get_drupal_prefix();
+    $drupal_prefix = $this->get_drupal_prefix();
     $test_schema_base_names = \Drupal::config('tripaldbx.settings')
       ->get('test_schema_base_names')
     ;
@@ -597,7 +597,7 @@ class ConnectionTest extends KernelTestBase {
    * @cover ::setExtraSchema
    */
   public function testConnectionScenario1() {
-    $drupal_prefix = $this->testhelper_get_drupal_prefix();
+    $drupal_prefix = $this->get_drupal_prefix();
     $test_schema_base_names = \Drupal::config('tripaldbx.settings')
       ->get('test_schema_base_names')
     ;
@@ -679,7 +679,7 @@ class ConnectionTest extends KernelTestBase {
    * @cover ::clearExtraSchemas
    */
   public function testConnectionScenario2() {
-    $drupal_prefix = $this->testhelper_get_drupal_prefix();
+    $drupal_prefix = $this->get_drupal_prefix();
     $test_schema_base_names = \Drupal::config('tripaldbx.settings')
       ->get('test_schema_base_names')
     ;
@@ -738,7 +738,7 @@ class ConnectionTest extends KernelTestBase {
    * @cover ::setExtraSchema
    */
   public function testConnectionScenario3() {
-    $drupal_prefix = $this->testhelper_get_drupal_prefix();
+    $drupal_prefix = $this->get_drupal_prefix();
     $test_schema_base_names = \Drupal::config('tripaldbx.settings')
       ->get('test_schema_base_names')
     ;
@@ -1006,7 +1006,7 @@ class ConnectionTest extends KernelTestBase {
   /**
    * HELPER: Retrieve the Drupal table prefix for the current site.
    */
-  protected function testhelper_get_drupal_prefix() {
+  protected function get_drupal_prefix() {
     $database_options = \Drupal::database()->getConnectionOptions();
 
     $drupal_prefix = '';

--- a/tripal/tests/src/Functional/TripalVocabTermPluginTest.php
+++ b/tripal/tests/src/Functional/TripalVocabTermPluginTest.php
@@ -97,13 +97,13 @@ class TripalVocabTermPluginTest extends BrowserTestBase {
     // --Test creation of a TripalTerm provided the expected input.
     //   NOTE: the use Drupal\tripal\TripalVocabTerms\TripalTerm
     //   at the top of this file allows us to use TripalTerm here.
-    $term = new TripalTerm(
-      'gene',
-      'A region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene may include regulatory regions, transcribed regions and/or other functional sequence regions.',
-      'SO',
-      '0000704',
-      'Sequence Ontology'
-    );
+    $term = new TripalTerm([
+      'name' => 'gene',
+      'definition' => 'A region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene may include regulatory regions, transcribed regions and/or other functional sequence regions.',
+      'idSpace' => 'SO',
+      'accession' => '0000704',
+      'vocabulary' => 'sequence'
+    ]);
     $this->assertIsObject(
       $term,
       'When trying to create a new TripalTerm, an object was not produced.'

--- a/tripal/tests/src/Functional/TripalVocabTermPluginTest.php
+++ b/tripal/tests/src/Functional/TripalVocabTermPluginTest.php
@@ -30,7 +30,7 @@ class TripalVocabTermPluginTest extends BrowserTestBase {
 
 		// Test the Vocabulary Plugin Manager.
 		// --Ensure we can instantiate the plugin manager.
-		$type = \Drupal::service('plugin.manager.tripal.vocab');
+		$type = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
 		// Note: If the plugin manager is not found you will get a ServiceNotFoundException.
 		$this->assertIsObject($type, 'A vocabulary plugin service object was not returned.');
 
@@ -62,7 +62,7 @@ class TripalVocabTermPluginTest extends BrowserTestBase {
 
 		// Test the Id Space Plugin Manager.
 		// --Ensure we can instantiate the plugin manager.
-		$type = \Drupal::service('plugin.manager.tripal.id_space');
+		$type = \Drupal::service('tripal.collection_plugin_manager.idspace');
 		// Note: If the plugin manager is not found you will get a ServiceNotFoundException.
 		$this->assertIsObject($type, 'An id space plugin service object was not returned.');
 

--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -112,7 +112,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
    * This function queries the `db` table of Chado to get the values
    * for the ID space.
    *
-   * @return
+   * @return array
    *   An associative array containing the columns of the `db1 table
    *   of Chado or NULL if the db could not be found.
    */
@@ -123,10 +123,11 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       ->condition('db.name', $this->getName(), '=')
       ->fields('db', ['name', 'url', 'urlprefix', 'description']);
     $result = $query->execute();
-    if ($result) {
-      return $result->fetchAssoc();
+    if (!$result) {
+      return NULL;
     }
-    return NULL;
+    return $result->fetchAssoc();
+    
   }     
   
   /**
@@ -151,28 +152,66 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       return NULL;
     }
     
+    $terms = [];
+    
+    $cvterm = $this->getChadoCVTerm($parent);
+    
+    $query = $this->chado->select('1:cvterm_relationship', 'CVTR');
+    $query->join('1:cvterm', 'CVTSUB', '"CVTR".subject_id = "CVTSUB".cvterm_id');
+    $query->join('1:cvterm', 'CVTTYPE', '"CVTR".type_id = "CVTTYPE".cvterm_id');
+    $query->join('1:dbxref', 'DBXSUB', '"CVTSUB".dbxref_id = "DBXSUB".dbxref_id');
+    $query->join('1:dbxref', 'DBXTYPE', '"CVTTYPE".dbxref_id = "DBXTYPE".dbxref_id');
+    $query->join('1:db', 'DBSUB', '"DBSUB".db_id = "DBXSUB".db_id');
+    $query->join('1:cv', 'CVSUB', '"CVSUB".cv_id = "CVTSUB".cv_id');
+    $query->join('1:db', 'DBTYPE', '"DBTYPE".db_id = "DBXTYPE".db_id');
+    $query->join('1:cv', 'CVTYPE', '"CVTYPE".cv_id = "CVTTYPE".cv_id');
+    $query->fields('CVTSUB', ['name'])
+      ->fields('DBXSUB', ['accession'])
+      ->fields('DBSUB', ['name'])
+      ->fields('CVSUB', ['name'])
+      ->fields('CVTTYPE', ['name'])
+      ->fields('DBXTYPE', ['accession'])
+      ->fields('DBTYPE', ['name'])
+      ->fields('CVTYPE', ['name'])
+      ->condition('CVTR.object_id', $cvterm->cvterm_id, '=');
+    $children = $query->execute();
+    while ($child = $children->fetchObject()) {
+      $child_term = new TripalTerm([
+        'name' => $child->name,
+        'accession' => $child->accession,
+        'idSpace' => $child->DBSUB_name,
+        'vocabulary' => $child->CVSUB_name
+      ]);
+      $type_term = new TripalTerm([
+        'name' => $child->CVTTYPE_name,
+        'accession' => $child->DBXTYPE_accession,
+        'idSpace' => $child->DBTYPE_name,
+        'vocabulary' => $child->CVTYPE_name
+      ]);
+      $terms[] = [$child_term, $type_term];
+    }
+    return $terms;
   }
   
   /**
    * {@inheritdoc}
    */
-  public function getTerm($accession) {
+  public function getTerm($accession, $options = []) {
     
     if (!$this->is_valid) {
       return NULL;
-    }
+    }    
     
     // Get the term record.
-    $cvterm = $this->chado->select('1:cvterm', 'CVT')
-      ->join('1:dbxterm', 'DBX', 'CVT.dbxref_id = DBX.dbxref_id')
-      ->join('1:cv', 'CV', 'CV.cv_id = CVT.cv_id')
-      ->join('1:db', 'DB', 'DB.db_id = DBX.db_id')
-      ->fields('CVT', ['cvterm_id', 'name', 'definition', 'is_obsolete', 'is_relationship_type'])
+    $query = $this->chado->select('1:cvterm', 'CVT');
+    $query->join('1:dbxref', 'DBX', '"CVT".dbxref_id = "DBX".dbxref_id');
+    $query->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
+    $query->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
+    $query->fields('CVT', ['cvterm_id', 'name', 'definition', 'is_obsolete', 'is_relationshiptype'])
       ->condition('DB.name', $this->getName(), '=')
-      ->condition('CV.name', $this->getDefaultVocab(), '=')
-      ->condition('DBX.accession', $accession, '=')
-      ->execute()
-      ->fetchObject();
+      ->condition('CV.name', $this->getDefaultVocabulary(), '=')
+      ->condition('DBX.accession', $accession, '=');
+    $cvterm = $query->execute()->fetchObject();
     if (!$cvterm) {
       return NULL;
     }
@@ -181,71 +220,194 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       'definition' => $cvterm->definition,
       'accession' => $accession,
       'idSpace' => $this->getName(),
-      'vocabulary' => $this->getDefaultVocabulary()
+      'vocabulary' => $this->getDefaultVocabulary(),
+      'is_obsolete' => $cvterm->is_obsolete == 1 ? True : False,
+      'is_relationship_type' => $cvterm->is_relationshiptype == 1 ? True : False,
     ]);
     
     // Set the boolean values for the term.
     if ($cvterm->is_obsolete) {
       $term->isObsolete(True);
     }
-    if ($cvterm->is_relationship_type) {
+    if ($cvterm->is_relationshiptype) {
       $term->isRelationshipType(True);
     }
     
     // Are there synonyms?
-    $synonyms = $this->chado->select('1:cvtermsynonym', 'CVTS')
-      ->fields('CVTS', ['synonym', 'type_id'])
-      ->condition('CVTS.cvterm_id', $cvterm->cvterm_id, '=')
-      ->execute();
-    while ($synonym = $synonyms->fetchObject()) {
-      $term->addSynonym($synonym->synonym);
+    if (!array_key_exists('includes', $options) or in_array('synonyms', $options['includes'])) {
+      $query = $this->chado->select('1:cvtermsynonym', 'CVTS');      
+      $query->leftJoin('1:cvterm', 'CVT', '"CVT".cvterm_id = "CVTS".type_id');
+      $query->leftJoin('1:dbxref', 'DBX', '"DBX".dbxref_id = "CVT".dbxref_id');
+      $query->leftJoin('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
+      $query->leftJoin('1:db', 'DB', '"DB".db_id = "DBX".db_id');
+      $query->fields('CVTS', ['synonym', 'type_id']);
+      $query->fields('CVT', ['name', 'definition']);
+      $query->fields('DBX', ['accession']);
+      $query->fields('CV', ['name']);
+      $query->fields('DB', ['name']);
+      $query->condition('CVTS.cvterm_id', $cvterm->cvterm_id, '=');
+      $synonyms = $query->execute();
+      while ($synonym = $synonyms->fetchObject()) {
+        $type_term = NULL;
+        if ($synonym->type_id) {
+          $type_term = new TripalTerm([
+            'name' => $synonym->name,
+            'definition' => $synonym->definition,
+            'accession' => $synonym->accession,
+            'idSpace' => $synonym->DB_name,
+            'vocabulary' => $synonym->CV_name,
+          ]);
+        }
+        $term->addSynonym($synonym->synonym, $type_term);
+      }
     }
     
     // Are there alt IDs?
-    $alt_ids = $this->chado->select('1:cvterm_dbxref', 'CVTDBX')
-      ->join('1:dbxref', 'DBX', 'CVTDBX.dbxref_id = DBX.dbxref_id')
-      ->join('1:db', 'DB', 'DB.db_id = DBX.db_id')
-      ->fields('DBX', ['accession'])
-      ->fields('DB', ['name'])
-      ->condition('CVTDBX.cvterm_id', $cvterm->cvterm_id, '=')
-      ->execute();          
-    while ($alt_id = $alt_ids->fetchObject()) {
-      $term->addAltId($alt_id->name, $alt_id->accession);
+    if (!array_key_exists('includes', $options) or in_array('altIds', $options['includes'])) {
+      $query = $this->chado->select('1:cvterm_dbxref', 'CVTDBX');
+      $query->join('1:dbxref', 'DBX', '"CVTDBX".dbxref_id = "DBX".dbxref_id');
+      $query->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
+      $query->fields('DBX', ['accession'])
+        ->fields('DB', ['name'])
+        ->condition('CVTDBX.cvterm_id', $cvterm->cvterm_id, '=');
+      $alt_ids = $query->execute();          
+      while ($alt_id = $alt_ids->fetchObject()) {
+        $term->addAltId($alt_id->name, $alt_id->accession);
+      }
     }
     
     // Are there properties?
-    $properties = $this->chado->select('1:cvtermprop', 'CVTP')    
-      ->join('1:cvterm', 'CVT', 'CVTP.type_id = CVT.cvterm_id')
-      ->join('1:dbxref', 'DBX', 'CVT.dbxref_id = DBX.dbxref_id')
-      ->join('1:db', 'DB', 'DB.db_id = DBX.db_id')
-      ->join('1:cv', 'CV', 'CV.cv_id = CVT.cv_id')
-      ->fields('CVT', ['name as cvname'])
-      ->fields('CVTP', ['value'])
-      ->fields('DBX', ['accession'])
-      ->fields('DB', ['name as dbname'])
-      ->condition('CVTP.cvterm_id', $cvterm->cvterm_id, '=')
-      ->orderBy('CVTP.type_id', 'ASC')
-      ->orderBy('CVTP.rank', 'ASC')
-      ->execute();
+    if (!array_key_exists('includes', $options) or in_array('properties', $options['includes'])) {
+      $query = $this->chado->select('1:cvtermprop', 'CVTP');    
+      $query->join('1:cvterm', 'CVT', '"CVTP".type_id = "CVT".cvterm_id');
+      $query->join('1:dbxref', 'DBX', '"CVT".dbxref_id = "DBX".dbxref_id');
+      $query->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
+      $query->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
+      $query->fields('CVT', ["name"])
+        ->fields('CVTP', ['value'])
+        ->fields('DBX', ['accession'])
+        ->fields('DB', ['name'])
+        ->fields('CV', ['name'])
+        ->condition('CVTP.cvterm_id', $cvterm->cvterm_id, '=')
+        ->orderBy('CVTP.type_id', 'ASC')
+        ->orderBy('CVTP.rank', 'ASC');
+      $properties = $query->execute();
       while ($property = $properties->fetchObject()) {
         $prop_term = new TripalTerm([
           'name' => $property->name,
           'accession' => $property->accession,
-          'idSpace' => $property->dbname,
-          'vocabulary' => $property->cvname
+          'idSpace' => $property->DB_name,
+          'vocabulary' => $property->CV_name
         ]);
         $term->addProperty($prop_term, $property->value);
       }
+    }
       
-      // Are there parents?
-        
+    // Are there parents?
+    if (!array_key_exists('includes', $options) or in_array('parents', $options['includes'])) {
+      $query = $this->chado->select('1:cvterm_relationship', 'CVTR');
+      $query->join('1:cvterm', 'CVTOBJ', '"CVTR".object_id = "CVTOBJ".cvterm_id');
+      $query->join('1:cvterm', 'CVTTYPE', '"CVTR".type_id = "CVTTYPE".cvterm_id');
+      $query->join('1:dbxref', 'DBXOBJ', '"CVTOBJ".dbxref_id = "DBXOBJ".dbxref_id');
+      $query->join('1:dbxref', 'DBXTYPE', '"CVTTYPE".dbxref_id = "DBXTYPE".dbxref_id');
+      $query->join('1:db', 'DBOBJ', '"DBOBJ".db_id = "DBXOBJ".db_id');
+      $query->join('1:cv', 'CVOBJ', '"CVOBJ".cv_id = "CVTOBJ".cv_id');
+      $query->join('1:db', 'DBTYPE', '"DBTYPE".db_id = "DBXTYPE".db_id');
+      $query->join('1:cv', 'CVTYPE', '"CVTYPE".cv_id = "CVTTYPE".cv_id');
+      $query->fields('CVTOBJ', ['name'])
+        ->fields('DBXOBJ', ['accession'])
+        ->fields('DBOBJ', ['name'])
+        ->fields('CVOBJ', ['name'])
+        ->fields('CVTTYPE', ['name'])
+        ->fields('DBXTYPE', ['accession'])
+        ->fields('DBTYPE', ['name'])
+        ->fields('CVTYPE', ['name'])
+        ->condition('CVTR.subject_id', $cvterm->cvterm_id, '=');
+      $parents = $query->execute();
+      while ($parent = $parents->fetchObject()) {
+        $parent_term = new TripalTerm([
+          'name' => $parent->name,
+          'accession' => $parent->accession,
+          'idSpace' => $parent->DBOBJ_name,
+          'vocabulary' => $parent->CVOBJ_name
+        ]);
+        $type_term = new TripalTerm([
+          'name' => $parent->CVTTYPE_name,
+          'accession' => $parent->DBXTYPE_accession,
+          'idSpace' => $parent->DBTYPE_name,
+          'vocabulary' => $parent->CVTYPE_name
+        ]);
+        $term->addParent($parent_term, $type_term);    
+      }
+    }    
+    
+    return $term;
   }
   
   /**
    * {@inheritdoc}
    */
-  public function getTerms($name, $options){
+  public function getTerms($name, $options = []) {
     
+    // The list of terms to return
+    $terms = [];
+    
+    // Build the query for matching via the `cvterm.name` column.
+    $query1 = $this->chado->select('1:cvterm', 'CVT');
+    $query1->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');    
+    $query1->join('1:dbxref', 'DBX', '"DBX".dbxref_id = "CVT".dbxref_id');
+    $query1->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
+    $query1->fields('CVT', ['name', 'definition', 'cvterm_id']);
+    $query1->fields('DBX', ['accession']);
+    $query1->fields('CV', ['name']);
+    $query1->condition('DB.name', $this->getName(), '=');    
+    if (array_key_exists('exact', $options) and $options['exact'] === True) {
+      $query1->condition('CVT.name', $name, '=');
+    }
+    else {
+      $query1->condition('CVT.name', $name . '%', 'LIKE');
+    }
+    $results = $query1->execute();
+    while ($cvterm = $results->fetchObject()) {
+      $term = new TripalTerm([
+        'name' => $cvterm->name,
+        'idSpace' => $this->getName(),
+        'vocabulary' => $cvterm->CV_name,
+        'definition' => $cvterm->definition,
+        'accession' => $cvterm->accession
+      ]);
+      $terms[$cvterm->name][$term->getTermId()] = $term;
+    }    
+    
+    // Build the query for matching via the `cvtermsynonym.synonym` column.
+    $query2 = $this->chado->select('1:cvtermsynonym', 'CS');
+    $query2->join('1:cvterm', 'CVT', '"CVT".cvterm_id = "CS".cvterm_id');
+    $query2->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');    
+    $query2->join('1:dbxref', 'DBX', '"DBX".dbxref_id = "CVT".dbxref_id');
+    $query2->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
+    $query2->fields('CVT', ['name', 'definition', 'cvterm_id']);
+    $query2->fields('DBX', ['accession']);
+    $query2->fields('CV', ['name']);
+    $query2->fields('CS', ['synonym']);
+    $query2->condition('DB.name', $this->getName(), '=');
+    if (array_key_exists('exact', $options) and $options['exact'] === True) {
+      $query2->condition('CS.synonym', $name, '=');
+    }
+    else {
+      $query2->condition('CS.synonym', $name . '%', 'LIKE');
+    }
+    $results = $query2->execute();
+    while ($cvterm = $results->fetchObject()) {
+      $term = new TripalTerm([
+        'name' => $cvterm->name,
+        'idSpace' => $this->getName(),
+        'vocabulary' => $cvterm->CV_name,
+        'definition' => $cvterm->definition,
+        'accession' => $cvterm->accession
+      ]);
+      $terms[$cvterm->synonym][$term->getTermId()] = $term;
+    }        
+    return $terms;
   }  
   
   /**
@@ -258,32 +420,43 @@ class ChadoIdSpace extends TripalIdSpaceBase {
   /**
    * {@inheritdoc}
    */
-  public function saveTerm($term, $options) {
-    $accession = $term->getAccession();
+  public function saveTerm($term, $options = []) {
     
+    // Don't save terms that aren't valid
+    if (!$term->isValid()) {
+      $this->messageLogger->error('ChadoIdSpace::saveTerm(). The term is not valid and cannot be saved.');      
+      return False;
+    }
+    
+    // Make sure the idSpace matches.
+    if ($this->getName() != $term->getIdSpace()) {
+      $this->messageLogger->error('ChadoIdSpace::saveTerm(). The term to save does not have the same ID space as this one.');
+      return False;      
+    }   
+    
+    // Get easy to use boolean variables.
     $fail_if_exists = False;
-    $update_parent = False;
     if (array_key_exists('failIfExists', $options)) {
       $fail_if_exists = $options['failIfExists'];
     }
-    if (array_key_exists('updateParent', $options)) {
-      $update_parent = $options['updateParent'];
+
+    // Does the term exist? If not do an insert, if so, do an update.
+    $cvterm = $this->getChadoCVTerm($term);
+    if (!$cvterm) {
+      if (!$this->insertTerm($term, $options)) {
+        return False;
+      }
     }
-    
-    $term_exists = $this->getTerm($accession);
-    if (!$term_exists) {
-      $this->insertTerm($term);
-    }
-    if ($term_exists and $fail_if_exists) {
+    if ($cvterm and $fail_if_exists) {
       return False;
     }
-    if ($term_exists and !$fail_if_exists) {
-      $this->updateTerm($term);
-    }
+    if ($cvterm and !$fail_if_exists) {
+      if (!$this->updateTerm($term, $cvterm, $options)) {
+        return False;
+      }
+    }    
     
-    
-    if ($update_parent) {
-    }       
+    return True;
   }
   
   /**
@@ -292,15 +465,19 @@ class ChadoIdSpace extends TripalIdSpaceBase {
    * @param TripalTerm $term
    *   The TripalTerm object to save.
    *   
-   * @return unknown
+   * @return object
    *   The cv record in object form.
    */
   protected function getChadoCV(TripalTerm $term) {
-    return $this->chado->select('1:cv', 'CV')
+    
+    $result = $this->chado->select('1:cv', 'CV')
       ->fields('CV', ['cv_id', 'name', 'definition'])
       ->condition('name', $term->getVocabulary(), '=')
-      ->execute()
-      ->fetchObject();    
+      ->execute();
+    if(!$result) {
+      return NULL;
+    }
+    return $result->fetchObject();
   }
   
   /**
@@ -312,11 +489,15 @@ class ChadoIdSpace extends TripalIdSpaceBase {
    *   The db record in object form.
    */
   protected function getChadoDB(TripalTerm $term) {
-    return $this->chado->select('1:db', 'DB')
+    
+    $result = $this->chado->select('1:db', 'DB')
       ->fields('DB', ['db_id', 'name', 'description'])
       ->condition('name', $term->getIdSpace(), '=')
-      ->execute()
-      ->fetchObject();    
+      ->execute();
+    if(!$result) {
+      return NULL;
+    }
+    return $result->fetchObject();
   }
   
   /**
@@ -328,16 +509,76 @@ class ChadoIdSpace extends TripalIdSpaceBase {
    *   The dbxref record in object form.
    */
   protected function getChadoDBXref(TripalTerm $term) {
-    return $this->chado->select('1:dbxref', 'DBX')
-      ->fields('DBX', ['dbxref_id'])
-      ->condition('db_id', $this->_getChadoDBId($term), '=')
+    
+    $db = $this->getChadoDB($term);
+    $result = $this->chado->select('1:dbxref', 'DBX')
+      ->fields('DBX', ['dbxref_id', 'db_id', 'accession', 'version' ,'description'])
+      ->condition('db_id', $db->db_id, '=')
       ->condition('accession', $term->getAccession(), '=')
-      ->execute()
-      ->fetchObject();
+      ->execute();
+    if (!$result) {
+      return NULL;     
+    }
+    return $result->fetchObject();
   }
   
   /**
-   * Retrieve a record from the Chado cvterm table. 
+   * Retreives a record from the Cahdo dbxref table using the term ID.
+   * 
+   * @param string $term_id
+   *   The term ID (e.g. GO:0044708).
+   */
+  protected function getChadoDBXrefbyTermID(string $term_id) {
+    
+    list($db, $accession) = explode(':', $term_id);
+    $query = $this->chado->select('1:dbxref', 'DBX');
+    $query->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
+    $result = $query->fields('DBX', ['dbxref_id', 'db_id', 'accession', 'version' ,'description'])
+      ->condition('DB.name', $db, '=')
+      ->condition('DBX.accession', $accession, '=')
+      ->execute();
+    if(!$result) {
+      return NULL;
+    }
+    return $result->fetchObject();
+  }
+  
+  /**
+   * Adds a record from the Cahdo dbxref table using the term ID.
+   * 
+   * The database record must already exist.
+   * 
+   * @param string $term_id
+   *   The term ID (e.g. GO:0044708).
+   *   
+   * @return object|NULL
+   *   The dbxref Object.
+   */
+  protected function insertChadoDBxrefbyTermID(string $term_id) {
+    list($db, $accession) = explode(':', $term_id);
+    $result = $this->chado->select('1:db', 'DB')
+      ->fields('DB', ['db_id'])
+      ->condition('name', $db, '=')
+      ->execute();      
+    if (!$result) {
+      return NULL;
+    }
+    
+    $db_id = $result->fetchField();
+    $this->chado->insert('1:dbxref')
+      ->fields([
+        'db_id' => $db_id,
+        'accession' => $accession,
+      ])
+      ->execute();
+    return $this->getChadoDBXrefbyTermID($term_id);
+  }
+  
+  /**
+   * Retrieve a record from the Chado cvterm table.
+   * 
+   * This function uses the db.name (IdSpace), cv.name (vocabulary)
+   * and dbxref.accession values to uniquely identify a term in Chado.
    * 
    * @param TripalTerm $term
    *   The TripalTerm object to save.
@@ -345,17 +586,21 @@ class ChadoIdSpace extends TripalIdSpaceBase {
    *   The cvterm record in object form.
    */
   protected function getChadoCVTerm(TripalTerm $term) {
-    return $this->chado->select('1:cvterm', 'CVT')
-      ->join('1:dbxterm', 'DBX', 'CVT.dbxref_id = DBX.dbxref_id')
-      ->join('1:cv', 'CV', 'CV.cv_id = CVT.cv_id')
-      ->join('1:db', 'DB', 'DB.db_id = DBX.db_id')
-      ->fields('CVT', ['cv_id', 'name', 'definition', 'cv_id'])
-      ->fields('DBX', ['accession', 'dbxref_id', 'db_id'])
+   
+    $query = $this->chado->select('1:cvterm', 'CVT');
+    $query->join('1:dbxref', 'DBX', '"DBX".dbxref_id = "CVT".dbxref_id');
+    $query->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
+    $query->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');   
+    $query->fields('CVT', ['cv_id', 'cvterm_id', 'definition', 'is_obsolete', 'is_relationshiptype'])
+      ->fields('DBX', ['dbxref_id', 'accession'])
       ->condition('DB.name', $term->getIdSpace(), '=')
       ->condition('CV.name', $term->getVocabulary(), '=')
-      ->condition('DBX.accession', $term->getAccession(), '=')
-      ->execute()
-      ->fetchObject();
+      ->condition('DBX.accession', $term->getAccession(), '=');
+    $result = $query->execute();
+    if (!$result) { 
+      return NULL;
+    }
+    return $result->fetchObject();
   }
 
   
@@ -368,15 +613,25 @@ class ChadoIdSpace extends TripalIdSpaceBase {
    * @param Drupal\tripal\TripalVocabTerms\TripalTerm $term
    *   The term object to update
    *   
+   * @param array $options
+   *   The options passed to the saveTerm() function.
+   *   
    * @return boolean
    *   True if the insert was successful, false otherwise.
    */
-  protected function insertTerm(TripalTerm $term) {    
+  protected function insertTerm(TripalTerm $term, $options) {    
+    
     try {
+      // The CV and DB records should already exist.
       $cv = $this->getChadoCV($term);
+      $db = $this->getChadoDB($term);
+      
+      // The DBXref may already exist even though the
+      // term does not.  So, check first and if not then 
+      // add it.
       $dbxref = $this->getChadoDBXref($term);
       if (!$dbxref) {
-        $db = $this->getChadoDB($term);
+        
         $this->chado->insert('1:dbxref')
           ->fields([
             'db_id' => $db->db_id,
@@ -385,20 +640,138 @@ class ChadoIdSpace extends TripalIdSpaceBase {
         ->execute();
         $dbxref = $this->getChadoDBXref($term);
       }
+      
+      // Add the CVterm record.
       $this->chado->insert('1:cvterm')
         ->fields([
-          'cv_id' => $cv->cv__id,
+          'cv_id' => $cv->cv_id,
           'dbxref_id' => $dbxref->dbxref_id,
           'name' => $term->getName(),
           'definition' => $term->getDefinition(),
+          'is_obsolete' => $term->isObsolete() ? 1 : 0,
+          'is_relationshiptype' => $term->isRelationshipType() ? 1 : 0,
         ])
         ->execute();
+      $cvterm = $this->getChadoCVTerm($term);
+      if (!$cvterm) {
+        return False;
+      }
+      
+      // Now save the term attributes.
+      if (!$this->saveTermAttributes($term, $cvterm, $options)) {
+        return False;
+      }
+      
     } 
     catch (Exception $e) {
       $this->messageLogger->error('ChadoIdSpace::insertTerm(). could not insert the cvterm record: @message', 
           ['@message' => $e->getMessage()]);
       return False;
     }
+    return True;
+  }
+  
+  /**
+   * 
+   * @param TripalTerm $term
+   * @param object $cvterm
+   * @param array $options
+   * @return bool
+   */
+  protected function saveTermAttributes(TripalTerm $term, object $cvterm, array $options) : bool {
+    
+    $update_parent = False;
+    if (array_key_exists('updateParent', $options)) {
+      $update_parent = $options['updateParent'];
+    }    
+    
+    // Add in synonyms.ount($syns->chado->delete('1:cvtermsynonym')->condition('cvterm_id', $cvterm->cvterm_id)->execute();
+    $this->chado->delete('1:cvtermsynonym')->condition('cvterm_id', $cvterm->cvterm_id)->execute();
+    foreach ($term->getSynonyms() as $synonym => $type_term) {
+      $query = $this->chado->insert('1:cvtermsynonym');
+      if ($type_term) {
+        $type_cvterm = $this->getChadoCVTerm($type_term);
+        $query->fields([
+          'cvterm_id' => $cvterm->cvterm_id,
+          'synonym' => $synonym,
+          'type_id' => $type_cvterm->cvterm_id,
+        ]);
+      }
+      else {
+        $query->fields([
+          'cvterm_id' => $cvterm->cvterm_id,
+          'synonym' => $synonym,
+        ]);        
+      }
+      $query->execute();
+    }
+    
+    // Add in the properties
+    $this->chado->delete('1:cvtermprop')->condition('cvterm_id', $cvterm->cvterm_id)->execute();
+    foreach ($term->getProperties() as $term_id => $properties) {
+      foreach  ($properties as $rank => $tuple) {
+        $type_term = $this->getChadoCVTerm($tuple[0]);
+        if (!$type_term) {
+          return False;
+        }
+        $value = $tuple[1];
+        $this->chado->insert('1:cvtermprop')
+          ->fields([
+            'cvterm_id' => $cvterm->cvterm_id,
+            'type_id' => $type_term->cvterm_id,
+            'value' => $value,
+            'rank' => $rank
+          ])
+          ->execute();
+      }
+    }
+    
+    // Add in the alternate IDs.
+    $this->chado->delete('1:cvterm_dbxref')->condition('cvterm_id', $cvterm->cvterm_id)->execute();
+    foreach ($term->getAltIds() as $term_id) {
+      $alt_dbxref = $this->getChadoDBXrefbyTermID($term_id);
+      if (!$alt_dbxref) {      
+        $alt_dbxref = $this->insertChadoDBxrefbyTermID($term_id);
+        if (!$alt_dbxref) {
+          return False;
+        }
+      }
+      $this->chado->insert('1:cvterm_dbxref')
+        ->fields([
+          'cvterm_id' => $cvterm->cvterm_id,
+          'dbxref_id' => $alt_dbxref->dbxref_id,
+        ])
+        ->execute();
+    }
+    
+    // Add in the parents.
+    $this->chado->delete('1:cvterm_relationship')->condition('subject_id', $cvterm->cvterm_id)->execute();
+    foreach ($term->getParents() as $term_id => $tuple) {
+      $parent_term = $tuple[0];
+      $rel_term = $tuple[1];
+      $parent_term = $this->getChadoCVTerm($parent_term);
+      if (!$parent_term) {
+        return False;
+      }
+      $rel_cvterm = $this->getChadoCVTerm($rel_term);
+      if (!$rel_cvterm) {
+        return False;
+      }
+      $this->chado->insert('1:cvterm_relationship')
+        ->fields([
+          'type_id' => $rel_cvterm->cvterm_id,
+          'subject_id' => $cvterm->cvterm_id,
+          'object_id' => $parent_term->cvterm_id,
+        ])
+        ->execute();
+        
+      // Update the parent if requested to do so.
+      if ($update_parent) {        
+        $parent_idSpace = $parent_term->getIdSpaceObject();
+        $parent_idSpace->saveTerm($parent_term, ['failIfExists' => $options['failIfExists']]);
+      }
+    }
+    
     return True;
   }
   
@@ -410,34 +783,28 @@ class ChadoIdSpace extends TripalIdSpaceBase {
    * 
    * @param Drupal\tripal\TripalVocabTerms\TripalTerm $term
    *   The term object to update
+   * @param object $cvterm
+   *   The record object for the term to update from the Chado cvterm table.
+   * @param array $options
+   *   The options passed to the saveTerm() function.
    *   
    * @return boolean
    *   True if the update was successful, false otherwise.
    */
-  protected function updateTerm($term) {
-    $definition = $term->getDefinition();
-    $accession = $term->getAccession();
-    $name = $term->getName();
-    
+  protected function updateTerm(TripalTerm $term, object &$cvterm, array $options) {
     try {
-      $cv_id = $this->chado->select('1:cv', 'CV')
-        ->fields('CV', ['cv_id'])
-        ->condition('name', $this->getDefaultVocabulary(), '=')
-        ->execute()
-        ->fetchField();
-      $cvterm_id = $this->chado->select('1:cvterm', 'CVT')
-        ->fields('CVT', ['cvterm_id'])
-        ->condition('cv_id', $cv_id, '=')
-        ->condition('name', $name, '=')
-        ->execute()
-        ->fetchField();
-      $this->chado->insert('1:cvterm')
+      $this->chado->update('1:cvterm')
         ->fields([
-          'name' => $name,
-          'definition' => $definition,
+          'name' => $term->getName(),
+          'definition' => $term->getDefinition(),
+          'is_obsolete' => $term->isObsolete() ? 1 : 0,
+          'is_relationshiptype' => $term->isRelationshipType() ? 1 : 0,
         ])
-        ->condition('cvterm_id', $cvterm_id, '=')
+        ->condition('cvterm_id', $cvterm->cvterm_id)
         ->execute();
+      $cvterm = $this->getChadoCVTerm($term);
+        
+      $this->saveTermAttributes($term, $cvterm, $options);
     }
     catch (Exception $e) {
       $this->messageLogger->error('ChadoIdSpace: could not update the cvterm record: @message',

--- a/tripal_chado/tests/src/Functional/Plugin/ChadoVocabTermsTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/ChadoVocabTermsTest.php
@@ -28,8 +28,8 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
   protected function getCV($cvname) {
     
     $query = $this->chado->select('1:cv', 'cv')
-    ->condition('cv.name', $cvname, '=')
-    ->fields('cv', ['name', 'definition']);
+      ->condition('cv.name', $cvname, '=')
+      ->fields('cv', ['name', 'definition']);
     $result = $query->execute();
     if (!$result) {
       return [];
@@ -64,7 +64,16 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
    * @param string $cvterm_name
    */
   protected function getCVterm($cvname, $cvterm_name) {
-    
+    $query = $this->chado->select('1:cvterm', 'CVT');
+    $query->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
+    $query->fields('CVT', ['cv_id', 'name', 'cvterm_id', 'definition', 'is_obsolete', 'is_relationshiptype'])
+      ->condition('CVT.name', $cvterm_name, '=')
+      ->condition('CV.name', $cvname, '=');
+    $result = $query->execute();
+    if (!$result) {
+      return [];
+    }
+    return $result->fetchAssoc();
   }
   
   /**
@@ -345,7 +354,7 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
     $this->assertTrue($comment->getVocabulary() == 'rdfs', 'The "comment" TripalTerm returned an incorrect vocabulary.');
     $this->assertTrue($comment->getIdSpace() == 'rdfs', 'The "comment" TripalTerm returned an incorrect ID space.');
     $this->assertTrue($comment->getURL() == 'http://www.w3.org/2000/01/rdf-schema#comment', 'The "comment" TripalTerm returned an incorrect URL.');
-    
+        
     // Create a parent term using the built-in setters.
     $parent = new TripalTerm();
     $parent->setName('biological_process');
@@ -381,16 +390,16 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
     $this->assertTrue($parent->getVocabulary() == 'biological_process', 'The "biological_process" TripalTerm returned an incorrect vocabulary.');
     $this->assertTrue($parent->getIdSpace() == 'GO', 'The "biological_process" TripalTerm returned an incorrect ID space.');
     $this->assertTrue($parent->getURL() == 'http://amigo.geneontology.org/amigo/term/GO:0008150', 'The "biological_process" TripalTerm returned an incorrect URL.');
-    $this->assertTrue(in_array('biological process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
-    $this->assertTrue(in_array('physiological process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
-    $this->assertTrue(in_array('single organism process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
-    $this->assertTrue(in_array('single-organism process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('biological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('physiological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('single organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('single-organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
     $parent->removeSynonym('physiological process');
     $parent->removeSynonym('single-organism process');
-    $this->assertTrue(in_array('biological process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
-    $this->assertFalse(in_array('physiological process', $parent->getSynonyms()), 'The "biological_process" TripalTerm contains a synonym that should have been removed.');
-    $this->assertTrue(in_array('single organism process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
-    $this->assertFalse(in_array('single-organism process', $parent->getSynonyms()), 'The "biological_process" TripalTerm contains a synonym that should ahve been removed.');
+    $this->assertTrue(in_array('biological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertFalse(in_array('physiological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm contains a synonym that should have been removed.');
+    $this->assertTrue(in_array('single organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertFalse(in_array('single-organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm contains a synonym that should ahve been removed.');
     $this->assertTrue(in_array('GO:0000004', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
     $this->assertTrue(in_array('GO:0007582', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
     $this->assertTrue(in_array('GO:0044699', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
@@ -435,17 +444,17 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
     $this->assertTrue($parent->getDefinition() == $parent_definition, 'The "biological process" TripalTerm returned and incorrect definition.');
     $this->assertTrue($parent->getVocabulary() == 'biological_process', 'The "biological_process" TripalTerm returned an incorrect vocabulary.');
     $this->assertTrue($parent->getIdSpace() == 'GO', 'The "biological_process" TripalTerm returned an incorrect ID space.');
-    $this->assertTrue($parent->getURL() == 'http://amigo.geneontology.org/amigo/term/GO:0008150', 'The "biological_process" TripalTerm returned an incorrect URL.');
-    $this->assertTrue(in_array('biological process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
-    $this->assertTrue(in_array('physiological process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
-    $this->assertTrue(in_array('single organism process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
-    $this->assertTrue(in_array('single-organism process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue($parent->getURL() == 'http://amigo.geneontology.org/amigo/term/GO:0008150', 'The "biological_process" TripalTerm returned an incorrect URL.');    
+    $this->assertTrue(in_array('biological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('physiological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('single organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertTrue(in_array('single-organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
     $parent->removeSynonym('physiological process');
     $parent->removeSynonym('single-organism process');
-    $this->assertTrue(in_array('biological process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
-    $this->assertFalse(in_array('physiological process', $parent->getSynonyms()), 'The "biological_process" TripalTerm contains a synonym that should have been removed.');
-    $this->assertTrue(in_array('single organism process', $parent->getSynonyms()), 'The "biological_process" TripalTerm is missing a synonym.');
-    $this->assertFalse(in_array('single-organism process', $parent->getSynonyms()), 'The "biological_process" TripalTerm contains a synonym that should ahve been removed.');
+    $this->assertTrue(in_array('biological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertFalse(in_array('physiological process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm contains a synonym that should have been removed.');
+    $this->assertTrue(in_array('single organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm is missing a synonym.');
+    $this->assertFalse(in_array('single-organism process', array_keys($parent->getSynonyms())), 'The "biological_process" TripalTerm contains a synonym that should ahve been removed.');
     $this->assertTrue(in_array('GO:0000004', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
     $this->assertTrue(in_array('GO:0007582', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
     $this->assertTrue(in_array('GO:0044699', $parent->getAltIds()), 'The "biological_process" TripalTerm is missing an alternative ID.');
@@ -527,10 +536,323 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
     $dummy->setAccession('dummy');
     $this->assertTrue($dummy->isValid(), 'The dummy TripalTerm reports it is not valid when it is.');
        
-    // Test Saving the term
-    // @todo test trying to save when the term is invalid
-    // @todo make sure all of the term attributes are saved in the appropriate tables.
+    //
+    // Inserting (Saving) Terms to Chado.
+    //     
     
+    // We need to save the comment term first s this is used
+    // for a property in our new child term below.
+    $rdfs_id->saveTerm($comment);
+    $GO->saveTerm($parent);
+    $GO->saveTerm($is_a);
+    
+    $cvterm = $this->getCVterm('rdfs', 'comment');
+    $this->assertTrue(!empty($cvterm) and $cvterm['name'] == 'comment', 'The term did not save a proper cvterm record  (Test #1).');
+    $comment2 = $rdfs_id->getTerm('comment');
+    $this->assertFalse($comment2->isRelationshipType(), 'The getTerm function did not return a term with the is_relationshiptype value loaded properly.');    
+    
+    // Create a new term for saving.
+    $new_child_def = 'The internally coordinated responses (actions or inactions) of animals (individuals or groups) to internal or external stimuli, via a mechanism that involves nervous system activity. Source: PMID:20160973, GOC:ems, GOC:jl, ISBN:0395448956';
+    $new_child_comment = 'Note that this term is in the subset of terms that should not be used for direct gene product annotation. Instead, select a child term or, if no appropriate child term exists, please request a new term. Direct annotations to this term may be amended during annotation reviews. 2. While a broader definition of behavior encompassing plants and single cell organisms would be justified on the basis of some usage (see PMID:20160973 for discussion), GO uses a tight definition that limits behavior to animals and to responses involving the nervous system, excluding plant responses that GO classifies under development, and responses of unicellular organisms that has general classifications for covering the responses of cells in multicellular organisms (e.g. cell chemotaxis).';
+    $new_child = new TripalTerm([
+      'name' => 'behavior',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0007610',
+      'definition' => $new_child_def,
+      'altIDs' => [
+        ['GO', '0044709'],
+        ['GO', '0023032'],
+        ['GO', '0044708'],
+      ],
+      'synonyms' => [
+        'behavioral response to stimulus',
+        'behaviour',
+        'behavioural response to stimulus',
+        'single-organism behavior'
+      ],
+      'properties' => [
+        [$comment, $new_child_comment],
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);
+    $GO->saveTerm($new_child);
+    $cvterm = $this->getCVterm('biological_process', 'behavior');
+    $this->assertTrue(!empty($cvterm) and $cvterm['name'] == 'behavior', 'The term did not save a proper cvterm record (Test #2).');       
+    
+    // Now that the term is saved, load it and see if all of the attributes are properly set.
+    $new_child2 = $GO->getTerm('0007610');
+    $this->assertTrue($new_child2->getName() == 'behavior', 'The getTerm function did not return a term with the name loaded properly.');
+    $this->assertTrue($new_child2->getDefinition() == $new_child_def, 'The getTerm function did not return a term with the definition loaded properly.');
+    $this->assertFalse($new_child2->isObsolete(), 'The getTerm function did not return a term with the is_obsolete value loaded properly.');
+    $this->assertFalse($new_child2->isRelationshipType(), 'The getTerm function did not return a term with the is_obsolete value loaded properly.');
+    $props = $new_child2->getProperties();
+    $this->assertTrue(array_keys($props)[0] == 'rdfs:comment', 'The getTerm->getProperties function did not return properties in the correct format (keys).');
+    $this->assertTrue(count($props['rdfs:comment'][0]) == 2, 'The getTerm->getProperties function did not return properties in the correct format (tuples).');
+    $this->assertTrue($props['rdfs:comment'][0][0]->getName() == 'comment',  'The getTerm->getProperties function did not return properties in the correct format (type).');
+    $this->assertTrue($props['rdfs:comment'][0][1] == $new_child_comment, 'The getTerm->getProperties function did not return properties in the correct format (value).');
+    $altIds = $new_child2->getAltIds();
+    $this->assertTrue(in_array('GO:0044709', $altIds), 'The getTerm->getAltIds function did not return all of the term IDs (Test #1).');
+    $this->assertTrue(in_array('GO:0023032', $altIds), 'The getTerm->getAltIds function did not return all of the term IDs (Test #2).');
+    $this->assertTrue(in_array('GO:0044708', $altIds), 'The getTerm->getAltIds function did not return all of the term IDs (Test #3).');
+    $synonyms = $new_child2->getSynonyms();
+    $this->assertTrue(in_array('behavioral response to stimulus', array_keys($synonyms)), 'The getTerm->getSynonysm function did not return all of the synonyms (Test #1).');
+    $this->assertTrue(in_array('behaviour', array_keys($synonyms)), 'The getTerm->getSynonysm function did not return all of the synonyms (Test #2).');
+    $this->assertTrue(in_array('behavioural response to stimulus', array_keys($synonyms)), 'The getTerm->getSynonysm function did not return all of the synonyms (Test #3).');
+    $this->assertTrue(in_array('single-organism behavior', array_keys($synonyms)), 'The getTerm->getSynonysm function did not return all of the synonyms (Test #4).');
+    $parents = $new_child2->getParents();
+    $this->assertTrue(array_keys($parents)[0] == 'GO:0008150', 'The getTerm->getParents function did not return parents in the correct format (keys).');
+    $this->assertTrue($parents['GO:0008150'][0]->getName() == 'biological_process',  'The getTerm->getParents function did not return parents in the correct format (term).');
+    $this->assertTrue($parents['GO:0008150'][1]->getName() == 'is_a', 'The getTerm->getParents function did not return parents in the correct format (type).');
+    
+    //
+    // Updating (Saving) Terms in Chado.
+    //
+    
+    // Remove all optional attributes and save.
+    $new_child2->removeAltId('GO', '0044709');
+    $new_child2->removeAltId('GO', '0023032');
+    $new_child2->removeAltId('GO', '0044708');
+    $new_child2->removeSynonym('behavioral response to stimulus');
+    $new_child2->removeSynonym('behavioural response to stimulus');
+    $new_child2->removeSynonym('behaviour');
+    $new_child2->removeSynonym('single-organism behavior');
+    $new_child2->removeParent('GO', '0008150');
+    $new_child2->removeProperty('rdfs', 'comment', 0);
+    $GO->saveTerm($new_child2);     
+    $new_child3 = $GO->getTerm('0007610');
+    $this->assertTrue(count(array_keys($new_child3->getProperties())) == 0, 'Updates to a term are not removing properties correctly');
+    $this->assertTrue(count($new_child3->getAltIds()) == 0, 'Updates to a term are not removing alt IDs correctly');
+    $this->assertTrue(count(array_keys($new_child3->getSynonyms())) == 0, 'Updates to a term are not removing synonyms correctly');
+    $this->assertTrue(count(array_keys($new_child3->getParents())) == 0, 'Updates to a term are not removing parents correctly');
+    
+    // Add back in at least 1 attribute and save.
+    $new_child3->addSynonym('behaviour');
+    $new_child3->addAltId('GO', '0044708');
+    $new_child3->addParent($parent, $is_a);
+    $new_child3->addProperty($comment, $new_child_comment);
+    $GO->saveTerm($new_child3);
+    $new_child4 = $GO->getTerm('0007610');    
+    $this->assertTrue(count(array_keys($new_child4->getProperties())) == 1, 'Updates to a term are not adding properties correctly');
+    $this->assertTrue(count($new_child4->getAltIds()) == 1, 'Updates to a term are not adding alt IDs correctly');
+    $this->assertTrue(count(array_keys($new_child4->getSynonyms())) == 1, 'Updates to a term are not adding synonyms correctly');
+    $this->assertTrue(count(array_keys($new_child4->getParents())) == 1, 'Updates to a term are not adding parents correctly');
+    
+    // Test updating of the boolean values
+    $new_child4->setIsObsolete(True);
+    $new_child4->setIsRelationshipType(True);
+    $GO->saveTerm($new_child4);
+    $new_child5 = $GO->getTerm('0007610');
+    $this->assertTrue($new_child5->isRelationshipType(), 'Updates to the relationship type did not get set when updating a term.');
+    $this->assertTrue($new_child5->isObsolete(), 'Updates to the obsolete value did not get set when updating a term.');
+    $new_child5->setIsObsolete(False);
+    $new_child5->setIsRelationshipType(False);
+    $GO->saveTerm($new_child5);
+    $new_child6 = $GO->getTerm('0007610');
+    $this->assertFalse($new_child6->isRelationshipType(), 'Updates to the relationship type did not get unset when updating a term.');
+    $this->assertFalse($new_child6->isObsolete(), 'Updates to the obsolete value did not get unset when updating a term.');
+    
+    //
+    // Finding Terms
+    //
+    
+    // Restore the parent to it's full state.
+    $parent = new TripalTerm([
+      'name' => 'biological_process',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0008150',
+      'definition' => $parent_definition,
+      'altIDs' => [
+        ['GO', '0000004'],
+        ['GO', '0007582'],
+        ['GO', '0044699'],
+      ],
+      'synonyms' => [
+        'biological process',
+        'physiological process',
+        'single organism process',
+        'single-organism process',
+      ],
+      'properties' => [
+        [$comment, $parent_comment],
+      ],
+    ]);
+    
+    $GO->saveTerm($parent);
+    
+    // Restore the child to its full state.
+    $new_child = new TripalTerm([
+      'name' => 'behavior',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0007610',
+      'definition' => $new_child_def,
+      'altIDs' => [
+        ['GO', '0044709'],
+        ['GO', '0023032'],
+        ['GO', '0044708'],
+      ],
+      'synonyms' => [
+        'behavioral response to stimulus',
+        'behaviour',
+        'behavioural response to stimulus',
+        'single-organism behavior'
+      ],
+      'properties' => [
+        [$comment, $new_child_comment],
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);        
+    $GO->saveTerm($new_child);
+        
+    $terms = $GO->getTerms('behav');
+    $this->assertTrue(count(array_keys($terms)) == 4, 'Searching for a non exact term did not yield the correct number of matches.');
+    $this->assertTrue(in_array('behavior', array_keys($terms)), 'Searching for a term did not return the matched name of a term.');
+    $this->assertTrue(in_array('behavioral response to stimulus', array_keys($terms)), 'Searching for a term did not return the matched synonym of a term (Test #1).');
+    $this->assertTrue(in_array('behavioural response to stimulus', array_keys($terms)), 'Searching for a term did not return the matched synonym of a term  (Test #2).');
+    $this->assertTrue(in_array('behaviour', array_keys($terms)), 'Searching for a term did not return the matched synonym of a term  (Test #3).');
+    $terms = $GO->getTerms('behav', ['exact' => True]);
+    $this->assertTrue(count(array_keys($terms)) == 0, 'Searching for an exact term that does not match anything did not return 0 matches.');
+    $terms = $GO->getTerms('behavioral response to stimulus', ['exact' => True]);
+    $this->assertTrue(count(array_keys($terms)) == 1, 'Searching for an exact term using the synonym did not return a match.');
+    $terms = $GO->getTerms('biological');
+    $this->assertTrue(count(array_keys($terms)) == 2, 'Searching for a non exact term that should match two terms did not.');
+    
+    //
+    // Get Children
+    // 
+    
+    // Restore the child to it's full state.
+    $child = new TripalTerm([
+      'name' => 'biological phase',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'definition' => 'A distinct period or stage in a biological process or cycle.',
+      'accession' => '0044848',
+      'properties' => [
+        [$comment, $child_comment]
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);
+    $GO->saveTerm($child);
+    
+    $children = $GO->getChildren($parent);
+    $this->assertTrue(count($children) == 2, 'The number of children returned for the parent is incorrect.');
+    $child_names = [$children[0][0]->getName(), $children[1][0]->getName()];
+    $this->assertTrue(in_array('behavior', $child_names), 'The list of children for the parent does not have a correct child name (Test #1).');
+    $this->assertTrue(in_array('biological phase', $child_names), 'The list of children for the parent does not have a correct child name (Test #2).');
+    $rel_types = [$children[0][1]->getName(), $children[1][1]->getName()];
+    $this->assertTrue(in_array('is_a', $rel_types), 'The list of children relationship types for the parent does not have the correct type.');
+    
+    
+    //
+    // Testing synonym types.
+    //
+    
+    // Create a type for the synonyms.
+    $syn_vocab = $vmanager->createCollection("synonym_type", "chado_vocabulary");
+    $syn_id = $idsmanager->createCollection('synonym_type', "chado_id_space");
+    $exact = new TripalTerm();
+    $exact->setName('exact');
+    $exact->setIdSpace('synonym_type');
+    $exact->setVocabulary('synonym_type');
+    $exact->setAccession('exact'); 
+    $syn_id->saveTerm($exact);
+    
+    $new_child = new TripalTerm([
+      'name' => 'behavior',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0007610',
+      'definition' => $new_child_def,
+      'altIDs' => [
+        ['GO', '0044709'],
+        ['GO', '0023032'],
+        ['GO', '0044708'],
+      ],
+      'synonyms' => [
+        ['behavioral response to stimulus', $exact],
+        ['behaviour', $exact],
+        ['behavioural response to stimulus', $exact],
+        ['single-organism behavior', $exact]
+      ],
+      'properties' => [
+        [$comment, $new_child_comment],
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);
+    $GO->saveTerm($new_child);
+    $new_child = $GO->getTerm('0007610');
+    $synonyms = $new_child->getSynonyms();
+    $this->assertTrue(count(array_keys($synonyms)) == 4, 'The number of synonyms returned is not correct.');
+    $this->assertTrue(in_array('behavioral response to stimulus', array_keys($synonyms)), 'The synonyms is missing (Test #1).');
+    $this->assertTrue(in_array('behaviour', array_keys($synonyms)), 'The synonyms is missing (Test #2).');
+    $this->assertTrue(in_array('behavioural response to stimulus', array_keys($synonyms)), 'The synonyms is missing (Test #3).');
+    $this->assertTrue(in_array('single-organism behavior', array_keys($synonyms)), 'The synonyms is missing (Test #4).');
+    $this->assertTrue($synonyms['behavioral response to stimulus']->getName() == 'exact', 'The synonym type is incorrect (Test #1).');
+    $this->assertTrue($synonyms['behaviour']->getName() == 'exact', 'The synonym type is incorrect (Test #1).');
+    $this->assertTrue($synonyms['behavioural response to stimulus']->getName() == 'exact', 'The synonym type is incorrect (Test #1).');
+    $this->assertTrue($synonyms['single-organism behavior']->getName() == 'exact', 'The synonym type is incorrect (Test #1).');
+    
+    // Repeat the test,but adding the synonyms using setters.
+    $new_child = new TripalTerm([
+      'name' => 'behavior',
+      'idSpace' => 'GO',
+      'vocabulary' => 'biological_process',
+      'accession' => '0007610',
+      'definition' => $new_child_def,
+      'altIDs' => [
+        ['GO', '0044709'],
+        ['GO', '0023032'],
+        ['GO', '0044708'],
+      ],
+      'properties' => [
+        [$comment, $new_child_comment],
+      ],
+      'parents' => [
+        [$parent, $is_a]
+      ],
+    ]);
+    $GO->saveTerm($new_child);
+    $new_child = $GO->getTerm('0007610');
+    $synonyms = $new_child->getSynonyms();
+    $this->assertTrue(count($synonyms) == 0, 'There should be no synonyms but some were returned.');    
+    $new_child->addSynonym('behavioral response to stimulus', $exact);
+    $new_child->addSynonym('behaviour', $exact);
+    $GO->saveTerm($new_child);
+    $new_child = $GO->getTerm('0007610');
+    $synonyms = $new_child->getSynonyms();
+    $this->assertTrue(in_array('behavioral response to stimulus', array_keys($synonyms)), 'The synonyms is missing after using the addSynonyms function (Test #3).');
+    $this->assertTrue(in_array('behaviour', array_keys($synonyms)), 'The synonyms is missing after using the addSynonyms function (Test #2).');    
+    $this->assertTrue($synonyms['behavioral response to stimulus']->getName() == 'exact', 'The synonym type is incorrect after using the addSynonyms function (Test #1).');
+    $this->assertTrue($synonyms['behaviour']->getName() == 'exact', 'The synonym type is incorrect after using the addSynonyms function (Test #1).');
+    
+    //
+    // Saving an invalid term
+    //
+    $dummy = new TripalTerm();
+    $dummy->setName('dummy');
+    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #1)');
+    $dummy->setDefinition('dummy');
+    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #2)');
+    $dummy->setAccession('dummy');
+    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #3)');
+    $dummy->setIdSpace('GO');
+    $this->assertFalse($GO->saveTerm($dummy), 'An invalid term did not return False when saving (Test #4)');
+    $dummy->setVocabulary('biological_process');
+    $this->assertTrue($GO->saveTerm($dummy), 'A valid term did not return True when saving');
+    
+    // Try to save a term taht doesn't belong to the idSpace
+    $this->assertFalse($rdfs_id->saveTerm($dummy), 'A term that did not belong to an idSpace should not have been saved.');
   }
 }
 


### PR DESCRIPTION
This PR completes the implementation of the ChadoIDSpace, ChadoVocabulary and TripalTerm classes. They are now fully functional and there is a suite of 201 assertions that test the full functionality of these classes.  

I'm requesting to merge this PR into the `tvg1-129-TripalFields` branch by @4ctrl-alt-del but I think after Josh's review,  we can request to merge into the `9.x-4.1` branch so that these classes can be used in starting field development and elsewhere that terms are needed.  