### PR TITLE
Content Types Creation With Terms

### DIFF
--- a/tripal/src/TripalVocabTerms/TripalTerm.php
+++ b/tripal/src/TripalVocabTerms/TripalTerm.php
@@ -9,35 +9,35 @@ class TripalTerm {
 
   /**
    * Constructs a new term object.
-   * 
+   *
    * Either use the set functions of this object to provide
    * the necessary values or provide them using the $details argument.
-   * 
+   *
    * Use the isValid() function to make sure the term is valid
-   * before saving. A term must have the following values set to be 
+   * before saving. A term must have the following values set to be
    * valid:  name, idSpace, vocabulary, and  accession.
-   * 
+   *
    * The $details argument accepts the following keys and values
-   * 
+   *
    * - name: (string) the name of the term
    * - definition: (string) the definitino for the term
    * - is_obsolete: (bool) True if the term is obsolete. Default is False.
-   * - is_relationship_type: (bool) True if the term is a relationship type. 
+   * - is_relationship_type: (bool) True if the term is a relationship type.
    *   Default is False.
    * - idSpace: (array) the ID space name.
    * - vocabulary: (array) the vocabulary name.
    * - parents: (array) an array of parents where each element
-   *   in the array is a tuple of two values: a TripalTerm for the parent 
+   *   in the array is a tuple of two values: a TripalTerm for the parent
    *   and a second TripalTerm for the relationship.
    * - altIDs: (array) an array of alternate term IDs where each
-   *   element is a tuple of two values: the ID space name and 
+   *   element is a tuple of two values: the ID space name and
    *   the accession of the alternate term.
    * - synonyms: (array)  an array of synonyms where each
-   *   element is the synonym, or a list of typles containng the synonym 
+   *   element is the synonym, or a list of typles containng the synonym
    *   followed by the a TripalTerm for the synonym type. Usually the synonym
    *   types are terms with a name of: 'exact', 'broad', 'narrow' or 'related'.
-   * - properties:(array) an array of properties where each element is a 
-   *   tuple of two values: a TriaplTerm for the property type and a value. 
+   * - properties:(array) an array of properties where each element is a
+   *   tuple of two values: a TriaplTerm for the property type and a value.
    *   If the same property is used multiple times with different values,
    *   then the rank will be set in the order that they are provided.
    *
@@ -45,10 +45,10 @@ class TripalTerm {
    *   The name.
    */
   public function __construct(array $details = NULL) {
-    
+
     // Instantiate the TripalLogger.
-    $this->messageLogger = \Drupal::service('tripal.logger');    
-    
+    $this->messageLogger = \Drupal::service('tripal.logger');
+
     // Initalize the member variables.
     $this->name = '';
     $this->definition = '';
@@ -56,7 +56,7 @@ class TripalTerm {
     $this->is_obsolete = False;
     $this->is_relationship_type = False;
     $this->idSpace = '';
-    $this->vocabulary = '';    
+    $this->vocabulary = '';
     $this->parents = [];
     $this->altIds = [];
     $this->synonyms = [];
@@ -71,11 +71,11 @@ class TripalTerm {
       'parents' => False,
     ];
     $this->internalId = NULL;
-    
+
     if (!is_array($details)) {
       return;
     }
-    
+
     // Check for problems in the incoming $details argument.
     if (array_key_exists('is_obsolete', $details) and !is_bool($details['is_obsolete'])) {
       $this->messageLogger->error('TripalTerm::__construct(). The is_obsolete value must be boolean.');
@@ -83,7 +83,7 @@ class TripalTerm {
     if (array_key_exists('is_relationship_type', $details) and !is_bool($details['is_relationship_type'])) {
       $this->messageLogger->error('TripalTerm::__construct(). The is_relationship_type value must be boolean.');
     }
-        
+
     // Set the values provided.
     if (array_key_exists('name', $details)) {
       $this->setName($details['name']);
@@ -95,7 +95,7 @@ class TripalTerm {
       $this->setDefinition($details['definition']);
     }
     if (array_key_exists('idSpace', $details)) {
-      $this->setIdSpace($details['idSpace']);          
+      $this->setIdSpace($details['idSpace']);
     }
     if (array_key_exists('vocabulary', $details)) {
       $this->setVocabulary($details['vocabulary']);
@@ -142,16 +142,16 @@ class TripalTerm {
       }
     }
     if (array_key_exists('is_obsolete', $details)) {
-      $this->setIsObsolete($details['is_obsolete']);      
+      $this->setIsObsolete($details['is_obsolete']);
     }
     if (array_key_exists('is_relationship_type', $details)) {
       $this->setIsRelationshipType($details['is_relationship_type']);
     }
-  }  
-  
+  }
+
   /**
    * Indicates if this term is valid and can be saved.
-   * 
+   *
    * @return boolean
    *   True if valid, False otherwise.
    */
@@ -160,9 +160,9 @@ class TripalTerm {
       return True;
     }
     return False;
-    
+
   }
-  
+
   /**
    * Sets the ID space for the term.
    *
@@ -173,39 +173,41 @@ class TripalTerm {
     $manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
     $idsp = $manager->loadCollection($idSpace);
     if (!$idsp) {
-      $this->messageLogger->error('TripalTerm::setIdSpace(). The specified ID space does not exist.');
+      $this->messageLogger->error(t('TripalTerm::setIdSpace(). The specified ID space, "@idSpace", does not exist.',
+          ['@idSpace' => $idSpace]));
       return;
     }
     $this->idSpace = $idSpace;
   }
-  
+
   /**
    * Sets the vocabulary for the term.
-   * 
+   *
    * @param string $vocabulary
-   *   The name of the vocabulary.   
+   *   The name of the vocabulary.
    */
   public function setVocabulary(string $vocabulary) {
-    
+
     $manager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
     $vocab = $manager->loadCollection($vocabulary);
     if (!$vocab) {
-      $this->messageLogger->error('TripalTerm::setVocabulary(). The specified vocabulary does not exist.');
-      return;      
-    }    
+      $this->messageLogger->error(T('TripalTerm::setVocabulary(). The specified vocabulary, "@vocab" does not exist.',
+          ['@vocab' => $vocabulary]));
+      return;
+    }
     $this->vocabulary = $vocabulary;
   }
-  
+
   /**
    * Sets the term's description.
-   * 
+   *
    * @param string $description
    */
   public function setDefinition(string $definition) {
     $this->loaded_attributes['definition'] = True;
     $this->definition = $definition;
   }
-  
+
 
   /**
    * Returns a list of valid terms based off matches from the given partial term
@@ -295,10 +297,10 @@ class TripalTerm {
     $manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
     return $manager->loadCollection($this->idSpace);
   }
-  
+
   /**
-   * Returns an instance of this term's vocabulary. 
-   * 
+   * Returns an instance of this term's vocabulary.
+   *
    * @return Drupal\tripal\TripalVocabTerms\Interfaces\TripalVocabularyInterface
    *   The vocabulary instance.
    */
@@ -306,7 +308,7 @@ class TripalTerm {
     $manager = \Drupal::service('tripal.collection_plugin_manager.vocabulary');
     return $manager->loadCollection($this->vocabulary);
   }
-  
+
   /**
    * Sets this term's accession.
    *
@@ -348,11 +350,11 @@ class TripalTerm {
     $term_url = $idSpace->getURLPrefix();
     $idSpace_name = $idSpace->getName();
     $subbed = False;
-    
+
     if (!$term_url) {
       $this->messageLogger->warning('TripalTerm::getURL(). The ID space has no URL prefix.');
     }
-            
+
     // If the URL prefix has replacement tokens then apply those.
     if (preg_match('/\{db\}/', $term_url)) {
       $term_url = preg_replace("/\{db\}/", $idSpace_name, $term_url);
@@ -362,13 +364,13 @@ class TripalTerm {
       $term_url = preg_replace("/\{accession\}/", $this->accession, $term_url);
       $subbed = True;
     }
-    
-    // If no replacement tokens were applied then just add the term 
+
+    // If no replacement tokens were applied then just add the term
     // to the end.
     if (!$subbed) {
       $term_url = $term_url . $idSpace_name . ":" . $this->accession;
     }
-    
+
     return $term_url;
   }
 
@@ -402,7 +404,7 @@ class TripalTerm {
    *   True on success or false otherwise.
    */
   public function save($options) {
-    
+
     if(!$this->isValid()) {
       $this->messageLogger->error('TripalTerm::save(). Cannot save the term as it is not currently in a valid state.');
       return False;
@@ -410,65 +412,65 @@ class TripalTerm {
     $idspace = $this->getIdSpace();
     return $idspace->saveTerm($this, $options);
   }
-  
+
   /**
    * Retrieves the  ID for this term.
-   * 
-   * The term ID is the combination of the ID space and the 
+   *
+   * The term ID is the combination of the ID space and the
    * accession (e.g. GO:0008150).
-   * 
+   *
    * @return string
    *   The term ID.
    */
   public function getTermId() {
-    return $this->idSpace . ":" . $this->accession; 
+    return $this->idSpace . ":" . $this->accession;
   }
-  
+
   /**
    * Adds a parent term
-   * 
+   *
    * A term may have zero or more parents. A term without parents
    * will be considered a root term.  The relationship between the
    * child term and the parent must be specified by another term
    * indicating the relationship (e.g. `is_a`, `derives_from`, etc).
-   *   
+   *
    * @param Drupal\tripal\TripalVocabTerms\TripalTerm $parent
    *   The parent term or NULL.
-   *   
+   *
    * @param Drupal\tripal\TripalVocabTerms\TripalTerm $relationship
    *   The relationship term or NULL.
-   *   
+   *
    * @return bool
-   *   True on success or false otherwise.    
+   *   True on success or false otherwise.
    */
   public function addParent(TripalTerm $parent, TripalTerm $relationship) {
-    $this->loaded_attributes['parents'] = True;    
-    $this->parents[$parent->getTermId()] = [$parent, $relationship];   
+    $this->loaded_attributes['parents'] = True;
+    $this->parents[$parent->getTermId()] = [$parent, $relationship];
   }
-  
+
   /**
    * Returns the parents for this term.
-   * 
+   *
    * @return array
-   *   In the array, the key is the term ID for the parent (e.g. GO:0008150). 
-   *   The value is a tuple that should contain as its first element the 
+   *   In the array, the key is the term ID for the parent (e.g. GO:0008150).
+   *   The value is a tuple that should contain as its first element the
    *   parent term and the second element the relationship term.
    */
   public function getParents() {
-    return $this->parents; 
+    return $this->parents;
   }
-  
+
   /**
-   * Removes a parent from the term. 
-   * 
+   * Removes a parent from the term.
+   *
    * @param string $idSpace
    *   The ID space name of the parent term.
-   *   
+   *
    * @param string $accession
    *   The accession for the parent term.
-   *   
+   *
    * @return bool
-   *   True on success or false otherwise. 
+   *   True on success or false otherwise.
    */
   public function removeParent(string $idSpace, string $accession) : bool {
     $term_id = $idSpace . ':' . $accession;
@@ -476,16 +478,16 @@ class TripalTerm {
       unset($this->parents[$term_id]);
       return True;
     }
-    return False;   
+    return False;
   }
-  
-  
+
+
   /**
-   * Adds an alternative term ID for this term. 
-   * 
+   * Adds an alternative term ID for this term.
+   *
    * @param string $idSpace
    *   The ID space name of the parent term.
-   *   
+   *
    * @param string $accession
    *   The accession for the parent term.
    */
@@ -494,28 +496,28 @@ class TripalTerm {
     $term_id =  $idSpace . ':' . $accession;
     $this->altIds[$term_id] = 1;
   }
-  
+
   /**
    * Returns the list of alternate IDs for this term.
-   * 
+   *
    * @return array
    *   An array of term ID strings.
    */
   public function getAltIds() : array {
     return array_keys($this->altIds);
   }
-  
+
   /**
    * Removes an alternate ID from this term.
-   * 
+   *
    * @param string $idSpace
    *   The ID space name of the parent term.
-   *   
+   *
    * @param string $accession
    *   The accession for the parent term.
-   *   
+   *
    * @return bool
-   *   True on success or false otherwise. 
+   *   True on success or false otherwise.
    */
   public function removeAltId(string $idSpace, string $accession) : bool {
     $term_id = $idSpace . ':' . $accession;
@@ -523,24 +525,24 @@ class TripalTerm {
       unset($this->altIds[$term_id]);
       return True;
     }
-    return False;     
+    return False;
   }
-  
+
   /**
    * Adds a synonym for this term.
-   * 
-   * Some terms may have synonymous names. The synonym type 
+   *
+   * Some terms may have synonymous names. The synonym type
    * is usually one of the of the following terms: 'exact',
-   * 'broad', 'narrow', or 'related'. 
-   * 
-   * It is highly encouraged to always provide a type for the 
+   * 'broad', 'narrow', or 'related'.
+   *
+   * It is highly encouraged to always provide a type for the
    * synonym.
-   * 
-   * 
+   *
+   *
    * @param string $synonym
    *   The synonym.
    * @param Drupal\tripal\TripalVocabTerms\TripalTerm $type
-   *   An optional Tripal term indicating the type of synonym. 
+   *   An optional Tripal term indicating the type of synonym.
    */
   public function addSynonym(string $synonym, TripalTerm $type = NULL) {
     $this->loaded_attributes['synonyms'] = True;
@@ -549,24 +551,24 @@ class TripalTerm {
 
   /**
    * Removes a synonym from this term.
-   * 
+   *
    * @param string $synonym
    *   The synonym.
-   *   
+   *
    * @return bool
-   *   True on success or false otherwise. 
+   *   True on success or false otherwise.
    */
   public function removeSynonym(string $synonym) : bool {
     if (array_key_exists($synonym, $this->synonyms)) {
       unset($this->synonyms[$synonym]);
       return True;
     }
-    return False;    
+    return False;
   }
-  
+
   /**
    * Returns the list of synonyms for this term.
-   * 
+   *
    * @return array
    *   An associative array where the keys are the synonyms
    *   and the values the synonym type TripalTerm.
@@ -574,10 +576,10 @@ class TripalTerm {
   public function getSynonyms() : array {
     return $this->synonyms;
   }
-  
+
   /**
    * Sets if the term is obsolete or not.
-   * 
+   *
    * @param bool $is_obsolete
    *   True if the term is obsolete, False otherwise.
    */
@@ -585,17 +587,17 @@ class TripalTerm {
     $this->loaded_attributes['is_obsolete'] = True;
     $this->is_obsolete = $is_obsolete;
   }
-  
+
   /**
    * Indicates if this term is obsolete or not.
-   * 
+   *
    * @return bool
    *   True if the term is obsolete, False otherwise.
    */
   public function isObsolete() : bool {
     return $this->is_obsolete;
   }
-  
+
   /**
    * Sets if the term is a relationship type term.
    *
@@ -606,7 +608,7 @@ class TripalTerm {
     $this->loaded_attributes['is_relationship_type'] = True;
     $this->is_relationship_type = $is_relationship_type;
   }
-  
+
   /**
    * Indicates if the term is a relationship type term.
    *
@@ -616,43 +618,43 @@ class TripalTerm {
   public function isRelationshipType() : bool {
     return $this->is_relationship_type;
   }
-  
+
 
   /**
-   * Adds a property to this term. 
-   * 
+   * Adds a property to this term.
+   *
    * @param TripalTerm $term
    *   A term indicating the propery type.
    * @param string $value
    *   The value of the property.
    * @param int|NULL $rank
-   *   The rank (or order) of the value. If no rank is specified and if a 
+   *   The rank (or order) of the value. If no rank is specified and if a
    *   property of the same term is already present then the rank will be
    *   incremented for the next value added.
-   *   
+   *
    * @return bool
    *   True if the property was successfully added, False otherwise.
    */
   public function addProperty(TripalTerm $term, string $value, int $rank = NULL) : bool {
     $this->loaded_attributes['properties'] = True;
-    
+
     // Get the max rank for this property.
     $term_id = $term->getTermId();
     if (!array_key_exists($term_id, $this->properties)) {
       $this->properties[$term_id] = [];
     }
     $max_rank = count($this->properties[$term_id]);
-    
+
     // Make sure we aren't skipping a rank.
     for ($i = 0; $i < $max_rank; $i++) {
       if (!array_key_exists($i, $this->properties[$term_id])) {
-        $this->messageLogger->error('TripalTerm::addProperty. The property term ranks are out of order, cannot add a new property.');        
+        $this->messageLogger->error('TripalTerm::addProperty. The property term ranks are out of order, cannot add a new property.');
         return False;
       }
     }
-    
+
     // Make sure the user didn't ask for a rank that exeeds the next one.
-    if ($rank != NULL) {     
+    if ($rank != NULL) {
       if ($rank > $max_rank) {
         $this->messageLogger->error('TripalTerm::addProperty. The specified rank is higher than the next max rank.');
         return False;
@@ -661,16 +663,16 @@ class TripalTerm {
     else {
       $rank = $max_rank;
     }
-    
+
     // Set the property.
-    $this->properties[$term_id][$rank] = [$term, $value];    
+    $this->properties[$term_id][$rank] = [$term, $value];
     return True;
   }
-  
+
   /**
    * Retrieves the list of properties for this term.
-   * 
-   * @return array 
+   *
+   * @return array
    *  An associative array where the first level key is the term_id for the property.
    *  The second level key is the rank and the value is a tuple with the first element
    *  being the TripalTerm for the property type and the second being the propertly value.
@@ -678,21 +680,21 @@ class TripalTerm {
   public function getProperties() : array {
     return $this->properties;
   }
-  
+
   /**
    * Removes a property from the list of properties.
-   * 
+   *
    * @param string $idSpace
    *   The ID space name of the property term.
-   *   
+   *
    * @param string $accession
    *   The accession for the property term.
-   *   
+   *
    * @param int $rank
    *   The rank of the value to remove.
-   *   
+   *
    * @return bool
-   *   True on success or false otherwise. 
+   *   True on success or false otherwise.
 
    */
   public function removeProperty(string $idSpace, string $accession, int $rank) : bool {
@@ -706,14 +708,14 @@ class TripalTerm {
          return True;
        }
      }
-     $this->messageLogger->error('TripalTerm::removeProperty(). Could not find the property, "@prop", for removal.', 
+     $this->messageLogger->error('TripalTerm::removeProperty(). Could not find the property, "@prop", for removal.',
        ['@prop' => $term_id]);
      return False;
   }
-  
+
   /**
    * Indicates which attributes are loaded.
-   * 
+   *
    * A term may have any number of attributes that may or may not
    * be loaded. The array returned by this function will
    * indicatew which attributes are loaded and which are not. The
@@ -721,7 +723,7 @@ class TripalTerm {
    * indicating if the attribute has been loaded. If all attributes
    * are true then all all ahve been loaded and the term is complete.
    * If some attributes are False then the term is not complete.
-   * 
+   *
    * @return array
    *   An associative array with keys indicating the attributes
    *   and the value being a boolean where True indicates that the
@@ -749,20 +751,20 @@ class TripalTerm {
   public function getInternalId() {
     return $this->internalId;
   }
-  
-  
-  
+
+
+
   /**
    * An associative array listing the parents.
-   * 
-   * The key is the term ID for the parent (e.g. GO:0008150). The value is a 
+   *
+   * The key is the term ID for the parent (e.g. GO:0008150). The value is a
    * tuple that should contain as its first element the parent term
    * and the second element the relationship term.
-   * 
+   *
    * @var array
    */
-  private $parents;  
-  
+  private $parents;
+
   /**
    * The term name.
    *
@@ -783,7 +785,7 @@ class TripalTerm {
    * @var string
    */
   private $idSpace;
-  
+
   /**
    * The term accession.
    *
@@ -797,66 +799,66 @@ class TripalTerm {
    * @var string
    */
   private $vocabulary;
-  
-  
+
+
   /**
-   * An array of alternate IDs for this term. 
-   * 
-   * For easy lookup, this is an associative array where 
+   * An array of alternate IDs for this term.
+   *
+   * For easy lookup, this is an associative array where
    * the key is the term_id and the value is 1.
    * Using the term_id as the key also prevents duplication.
-   * 
+   *
    * @var array
    */
   private $altIds;
-  
-  
+
+
   /**
    * An array of synonyms.
-   * 
-   * For easy lookup, this is an associative array where 
+   *
+   * For easy lookup, this is an associative array where
    * the key is the synonym and the value is the type term..
-   * Using the synonym as the key also prevents duplication. 
-   * 
+   * Using the synonym as the key also prevents duplication.
+   *
    * @var array
    */
   private $synonyms;
-  
-  
+
+
   /**
    * Indicates if the term is obsolete or not.
-   * 
+   *
    * @var bool
    */
   private $is_obsolete;
-  
+
   /**
    * Indicates if the term is a relationship type.
-   * 
+   *
    * @var bool
    */
   private $is_relationship_type;
-  
+
   /**
    * A array of properties for this term.
-   * 
-   * The associative array first level key is the 
-   * term_id for the property, the second level key is the 
+   *
+   * The associative array first level key is the
+   * term_id for the property, the second level key is the
    * rank and the value is a tuple with the first element
-   * being the TripalTerm for the property type and 
+   * being the TripalTerm for the property type and
    * the second being the propertly value.
-   * 
+   *
    * @var array
    */
   private $properties;
-  
-  
+
+
   /**
    * An instance of the TripalLogger.
    */
   private $messageLogger = NULL;
-  
-  
+
+
   /**
    * An associative array indicating which attributes of the term are loaded.
    */

--- a/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
+++ b/tripal_chado/src/Plugin/TripalIdSpace/ChadoIdSpace.php
@@ -7,61 +7,62 @@ use Drupal\tripal\TripalVocabTerms\TripalTerm;
 
 /**
  * Chado Implementation of TripalIdSpaceBase
- * 
+ *
  *  @TripalIdSpace(
  *    id = "chado_id_space",
  *    label = @Translation("Vocabulary IDSpace in Chado"),
  *  )
  */
 class ChadoIdSpace extends TripalIdSpaceBase {
-  
-  protected $default_vocabulary = NULL;
-  
+
   /**
    * Holds the TripalDBX instance for accessing Chado.
    */
   protected $chado = NULL;
-    
-  
+
+
   /**
    * The definition for the `db` table of Chado.
    */
   protected $db_def = NULL;
-  
-  
+
+
   /**
    * An instance of the TripalLogger.
    */
   protected $messageLogger = NULL;
-  
+
   /**
    * A simple boolean to prevent Chado queries if the ID space isn't valid.
    */
   protected $is_valid = False;
-  
-  
+
+
   /**
    * {@inheritdoc}
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    
+
     // Instantiate the TripalLogger
     $this->messageLogger = \Drupal::service('tripal.logger');
-    
+
     // Instantiate a TripalDBX connection for Chado.
     $this->chado = \Drupal::service('tripal_chado.database');
-    
+
     // Get the chado definition for the `db` table.
     $this->db_def = $this->chado->schema()->getTableDef('db', ['Source' => 'file']);
+
+    // Check the name to make sure it's valid.
+    $this->isValid();
   }
-  
-  
+
+
   /**
    * {@inheritdoc}
    */
-  public function isValid() {    
-    
+  public function isValid() {
+
     // Make sure the name of this ID Space does not exceeed the allowed size in Chado.
     if (strlen($this->getName()) > $this->db_def['fields']['name']['size']) {
       $this->messageLogger->error('ChadoIdSpace: The IdSpace name must not be longer than @size characters. ' +
@@ -70,18 +71,18 @@ class ChadoIdSpace extends TripalIdSpaceBase {
            '@value' => $this->getName()]);
           return;
     }
-    
+
     $this->is_valid = True;
-    
+
     return $this->is_valid;
   }
-  
-  
+
+
   /**
    * {@inheritdoc}
    */
   public function create() {
-    
+
     // Check if the record already exists in the database, if it
     // doesn't then insert it.  We don't yet have the description,
     // URL prefix, etc but that's okay, the name is all that is
@@ -93,19 +94,19 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       $query->execute();
     }
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function destroy(){
     // The destroy function is meant to delete the ID space.
-    // But, because CVs and DBs are so critical to almost all 
-    // data in Chado we don't want to remove the records.  
-    // Let's let the collection be deleted as far as 
+    // But, because CVs and DBs are so critical to almost all
+    // data in Chado we don't want to remove the records.
+    // Let's let the collection be deleted as far as
     // Tripal is concerned but leave the record in Chado.
     // So, do nothing here.
-  }  
-  
+  }
+
   /**
    * Loads an ID Space record from Chado.
    *
@@ -117,8 +118,8 @@ class ChadoIdSpace extends TripalIdSpaceBase {
    *   of Chado or NULL if the db could not be found.
    */
   protected function loadIdSpace() {
-    
-    // Get the Chado `db` record for this ID space.    
+
+    // Get the Chado `db` record for this ID space.
     $query = $this->chado->select('1:db', 'db')
       ->condition('db.name', $this->getName(), '=')
       ->fields('db', ['name', 'url', 'urlprefix', 'description']);
@@ -127,35 +128,35 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       return NULL;
     }
     return $result->fetchAssoc();
-    
-  }     
-  
+
+  }
+
   /**
    * {@inheritdoc}
    */
   public function getParent($child){
-    
+
     // Don't get values for an ID space that isn't valid.
     if (!$this->is_valid) {
       return NULL;
     }
-    
+
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function getChildren($parent = NULL){
-    
+
     // Don't get values for an ID space that isn't valid.
     if (!$this->is_valid) {
       return NULL;
     }
-    
+
     $terms = [];
-    
+
     $cvterm = $this->getChadoCVTerm($parent);
-    
+
     $query = $this->chado->select('1:cvterm_relationship', 'CVTR');
     $query->join('1:cvterm', 'CVTSUB', '"CVTR".subject_id = "CVTSUB".cvterm_id');
     $query->join('1:cvterm', 'CVTTYPE', '"CVTR".type_id = "CVTTYPE".cvterm_id');
@@ -192,16 +193,16 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     }
     return $terms;
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function getTerm($accession, $options = []) {
-    
+
     if (!$this->is_valid) {
       return NULL;
-    }    
-    
+    }
+
     // Get the term record.
     $query = $this->chado->select('1:cvterm', 'CVT');
     $query->join('1:dbxref', 'DBX', '"CVT".dbxref_id = "DBX".dbxref_id');
@@ -224,10 +225,10 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       'is_obsolete' => $cvterm->is_obsolete == 1 ? True : False,
       'is_relationship_type' => $cvterm->is_relationshiptype == 1 ? True : False,
     ]);
-    
+
     // Set the internal ID.
     $term->setInternalId($cvterm->cvterm_id);
-    
+
     // Set the boolean values for the term.
     if ($cvterm->is_obsolete) {
       $term->isObsolete(True);
@@ -235,10 +236,10 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     if ($cvterm->is_relationshiptype) {
       $term->isRelationshipType(True);
     }
-    
+
     // Are there synonyms?
     if (!array_key_exists('includes', $options) or in_array('synonyms', $options['includes'])) {
-      $query = $this->chado->select('1:cvtermsynonym', 'CVTS');      
+      $query = $this->chado->select('1:cvtermsynonym', 'CVTS');
       $query->leftJoin('1:cvterm', 'CVT', '"CVT".cvterm_id = "CVTS".type_id');
       $query->leftJoin('1:dbxref', 'DBX', '"DBX".dbxref_id = "CVT".dbxref_id');
       $query->leftJoin('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
@@ -264,7 +265,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
         $term->addSynonym($synonym->synonym, $type_term);
       }
     }
-    
+
     // Are there alt IDs?
     if (!array_key_exists('includes', $options) or in_array('altIds', $options['includes'])) {
       $query = $this->chado->select('1:cvterm_dbxref', 'CVTDBX');
@@ -273,15 +274,15 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       $query->fields('DBX', ['accession'])
         ->fields('DB', ['name'])
         ->condition('CVTDBX.cvterm_id', $cvterm->cvterm_id, '=');
-      $alt_ids = $query->execute();          
+      $alt_ids = $query->execute();
       while ($alt_id = $alt_ids->fetchObject()) {
         $term->addAltId($alt_id->name, $alt_id->accession);
       }
     }
-    
+
     // Are there properties?
     if (!array_key_exists('includes', $options) or in_array('properties', $options['includes'])) {
-      $query = $this->chado->select('1:cvtermprop', 'CVTP');    
+      $query = $this->chado->select('1:cvtermprop', 'CVTP');
       $query->join('1:cvterm', 'CVT', '"CVTP".type_id = "CVT".cvterm_id');
       $query->join('1:dbxref', 'DBX', '"CVT".dbxref_id = "DBX".dbxref_id');
       $query->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
@@ -305,7 +306,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
         $term->addProperty($prop_term, $property->value);
       }
     }
-      
+
     // Are there parents?
     if (!array_key_exists('includes', $options) or in_array('parents', $options['includes'])) {
       $query = $this->chado->select('1:cvterm_relationship', 'CVTR');
@@ -340,30 +341,30 @@ class ChadoIdSpace extends TripalIdSpaceBase {
           'idSpace' => $parent->DBTYPE_name,
           'vocabulary' => $parent->CVTYPE_name
         ]);
-        $term->addParent($parent_term, $type_term);    
+        $term->addParent($parent_term, $type_term);
       }
-    }    
-    
+    }
+
     return $term;
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function getTerms($name, $options = []) {
-    
+
     // The list of terms to return
     $terms = [];
-    
+
     // Build the query for matching via the `cvterm.name` column.
     $query1 = $this->chado->select('1:cvterm', 'CVT');
-    $query1->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');    
+    $query1->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
     $query1->join('1:dbxref', 'DBX', '"DBX".dbxref_id = "CVT".dbxref_id');
     $query1->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
     $query1->fields('CVT', ['name', 'definition', 'cvterm_id']);
     $query1->fields('DBX', ['accession']);
     $query1->fields('CV', ['name']);
-    $query1->condition('DB.name', $this->getName(), '=');    
+    $query1->condition('DB.name', $this->getName(), '=');
     if (array_key_exists('exact', $options) and $options['exact'] === True) {
       $query1->condition('CVT.name', $name, '=');
     }
@@ -380,12 +381,12 @@ class ChadoIdSpace extends TripalIdSpaceBase {
         'accession' => $cvterm->accession
       ]);
       $terms[$cvterm->name][$term->getTermId()] = $term;
-    }    
-    
+    }
+
     // Build the query for matching via the `cvtermsynonym.synonym` column.
     $query2 = $this->chado->select('1:cvtermsynonym', 'CS');
     $query2->join('1:cvterm', 'CVT', '"CVT".cvterm_id = "CS".cvterm_id');
-    $query2->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');    
+    $query2->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
     $query2->join('1:dbxref', 'DBX', '"DBX".dbxref_id = "CVT".dbxref_id');
     $query2->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
     $query2->fields('CVT', ['name', 'definition', 'cvterm_id']);
@@ -409,34 +410,36 @@ class ChadoIdSpace extends TripalIdSpaceBase {
         'accession' => $cvterm->accession
       ]);
       $terms[$cvterm->synonym][$term->getTermId()] = $term;
-    }        
+    }
     return $terms;
-  }  
-  
+  }
+
   /**
    * {@inheritdoc}
    */
   public function getDefaultVocabulary(){
-    return $this->default_vocabulary;    
+    return $this->getDefaultVocabCache();
   }
-    
+
   /**
    * {@inheritdoc}
    */
   public function saveTerm($term, $options = []) {
-    
+
     // Don't save terms that aren't valid
     if (!$term->isValid()) {
-      $this->messageLogger->error('ChadoIdSpace::saveTerm(). The term is not valid and cannot be saved.');      
+      $this->messageLogger->error(t('ChadoIdSpace::saveTerm(). The term, "@term" is not valid and cannot be saved.',
+          ['@term' => $term->getIdSpace() . ':' . $term->getAccession()]));
       return False;
     }
-    
+
     // Make sure the idSpace matches.
     if ($this->getName() != $term->getIdSpace()) {
-      $this->messageLogger->error('ChadoIdSpace::saveTerm(). The term to save does not have the same ID space as this one.');
-      return False;      
-    }   
-    
+      $this->messageLogger->error(t('ChadoIdSpace::saveTerm(). The term, "@term", does not have the same ID space as this one.',
+          ['@term' => $term->getIdSpace() . ':' . $term->getAccession()]));
+      return False;
+    }
+
     // Get easy to use boolean variables.
     $fail_if_exists = False;
     if (array_key_exists('failIfExists', $options)) {
@@ -458,25 +461,25 @@ class ChadoIdSpace extends TripalIdSpaceBase {
         return False;
       }
     }
-    
+
     // Set the internal ID.
     $cvterm = $this->getChadoCVTerm($term);
     $term->setInternalId($cvterm->cvterm_id);
-    
+
     return True;
   }
-  
+
   /**
    * Retrieve a record from the Chado cv table.
-   * 
+   *
    * @param TripalTerm $term
    *   The TripalTerm object to save.
-   *   
+   *
    * @return object
    *   The cv record in object form.
    */
   protected function getChadoCV(TripalTerm $term) {
-    
+
     $result = $this->chado->select('1:cv', 'CV')
       ->fields('CV', ['cv_id', 'name', 'definition'])
       ->condition('name', $term->getVocabulary(), '=')
@@ -486,17 +489,17 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     }
     return $result->fetchObject();
   }
-  
+
   /**
    * Retrieve a record from the Chado db table.
-   * 
+   *
    * @param TripalTerm $term
-   *   The TripalTerm object to save. 
+   *   The TripalTerm object to save.
    * @return object
    *   The db record in object form.
    */
   protected function getChadoDB(TripalTerm $term) {
-    
+
     $result = $this->chado->select('1:db', 'DB')
       ->fields('DB', ['db_id', 'name', 'description'])
       ->condition('name', $term->getIdSpace(), '=')
@@ -506,17 +509,17 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     }
     return $result->fetchObject();
   }
-  
+
   /**
    * Retrieve a record from the Chado dbxref table.
-   * 
+   *
    * @param TripalTerm $term
-   *   The TripalTerm object to save. 
+   *   The TripalTerm object to save.
    * @return object
    *   The dbxref record in object form.
    */
   protected function getChadoDBXref(TripalTerm $term) {
-    
+
     $db = $this->getChadoDB($term);
     $result = $this->chado->select('1:dbxref', 'DBX')
       ->fields('DBX', ['dbxref_id', 'db_id', 'accession', 'version' ,'description'])
@@ -524,19 +527,19 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       ->condition('accession', $term->getAccession(), '=')
       ->execute();
     if (!$result) {
-      return NULL;     
+      return NULL;
     }
     return $result->fetchObject();
   }
-  
+
   /**
    * Retreives a record from the Cahdo dbxref table using the term ID.
-   * 
+   *
    * @param string $term_id
    *   The term ID (e.g. GO:0044708).
    */
   protected function getChadoDBXrefbyTermID(string $term_id) {
-    
+
     list($db, $accession) = explode(':', $term_id);
     $query = $this->chado->select('1:dbxref', 'DBX');
     $query->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
@@ -549,15 +552,15 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     }
     return $result->fetchObject();
   }
-  
+
   /**
    * Adds a record from the Cahdo dbxref table using the term ID.
-   * 
+   *
    * The database record must already exist.
-   * 
+   *
    * @param string $term_id
    *   The term ID (e.g. GO:0044708).
-   *   
+   *
    * @return object|NULL
    *   The dbxref Object.
    */
@@ -566,11 +569,11 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     $result = $this->chado->select('1:db', 'DB')
       ->fields('DB', ['db_id'])
       ->condition('name', $db, '=')
-      ->execute();      
+      ->execute();
     if (!$result) {
       return NULL;
     }
-    
+
     $db_id = $result->fetchField();
     $this->chado->insert('1:dbxref')
       ->fields([
@@ -580,65 +583,65 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       ->execute();
     return $this->getChadoDBXrefbyTermID($term_id);
   }
-  
+
   /**
    * Retrieve a record from the Chado cvterm table.
-   * 
+   *
    * This function uses the db.name (IdSpace), cv.name (vocabulary)
    * and dbxref.accession values to uniquely identify a term in Chado.
-   * 
+   *
    * @param TripalTerm $term
    *   The TripalTerm object to save.
    * @return object
    *   The cvterm record in object form.
    */
   protected function getChadoCVTerm(TripalTerm $term) {
-   
+
     $query = $this->chado->select('1:cvterm', 'CVT');
     $query->join('1:dbxref', 'DBX', '"DBX".dbxref_id = "CVT".dbxref_id');
     $query->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
-    $query->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');   
+    $query->join('1:db', 'DB', '"DB".db_id = "DBX".db_id');
     $query->fields('CVT', ['cv_id', 'cvterm_id', 'definition', 'is_obsolete', 'is_relationshiptype'])
       ->fields('DBX', ['dbxref_id', 'accession'])
       ->condition('DB.name', $term->getIdSpace(), '=')
       ->condition('CV.name', $term->getVocabulary(), '=')
       ->condition('DBX.accession', $term->getAccession(), '=');
     $result = $query->execute();
-    if (!$result) { 
+    if (!$result) {
       return NULL;
     }
     return $result->fetchObject();
   }
 
-  
+
   /**
    * Inserts a new term into Chado.
-   * 
-   * The term should be checked that it does not exist 
+   *
+   * The term should be checked that it does not exist
    * prior to calling this function.
-   *  
+   *
    * @param Drupal\tripal\TripalVocabTerms\TripalTerm $term
    *   The term object to update
-   *   
+   *
    * @param array $options
    *   The options passed to the saveTerm() function.
-   *   
+   *
    * @return boolean
    *   True if the insert was successful, false otherwise.
    */
-  protected function insertTerm(TripalTerm $term, $options) {    
-    
+  protected function insertTerm(TripalTerm $term, $options) {
+
     try {
       // The CV and DB records should already exist.
       $cv = $this->getChadoCV($term);
       $db = $this->getChadoDB($term);
-      
+
       // The DBXref may already exist even though the
-      // term does not.  So, check first and if not then 
+      // term does not.  So, check first and if not then
       // add it.
       $dbxref = $this->getChadoDBXref($term);
       if (!$dbxref) {
-        
+
         $this->chado->insert('1:dbxref')
           ->fields([
             'db_id' => $db->db_id,
@@ -647,7 +650,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
         ->execute();
         $dbxref = $this->getChadoDBXref($term);
       }
-      
+
       // Add the CVterm record.
       $this->chado->insert('1:cvterm')
         ->fields([
@@ -663,35 +666,35 @@ class ChadoIdSpace extends TripalIdSpaceBase {
       if (!$cvterm) {
         return False;
       }
-      
+
       // Now save the term attributes.
       if (!$this->saveTermAttributes($term, $cvterm, $options)) {
         return False;
       }
-      
-    } 
+
+    }
     catch (Exception $e) {
-      $this->messageLogger->error('ChadoIdSpace::insertTerm(). could not insert the cvterm record: @message', 
+      $this->messageLogger->error('ChadoIdSpace::insertTerm(). could not insert the cvterm record: @message',
           ['@message' => $e->getMessage()]);
       return False;
     }
     return True;
   }
-  
+
   /**
-   * 
+   *
    * @param TripalTerm $term
    * @param object $cvterm
    * @param array $options
    * @return bool
    */
   protected function saveTermAttributes(TripalTerm $term, object $cvterm, array $options) : bool {
-    
+
     $update_parent = False;
     if (array_key_exists('updateParent', $options)) {
       $update_parent = $options['updateParent'];
-    }    
-    
+    }
+
     // Add in synonyms.ount($syns->chado->delete('1:cvtermsynonym')->condition('cvterm_id', $cvterm->cvterm_id)->execute();
     $this->chado->delete('1:cvtermsynonym')->condition('cvterm_id', $cvterm->cvterm_id)->execute();
     foreach ($term->getSynonyms() as $synonym => $type_term) {
@@ -708,11 +711,11 @@ class ChadoIdSpace extends TripalIdSpaceBase {
         $query->fields([
           'cvterm_id' => $cvterm->cvterm_id,
           'synonym' => $synonym,
-        ]);        
+        ]);
       }
       $query->execute();
     }
-    
+
     // Add in the properties
     $this->chado->delete('1:cvtermprop')->condition('cvterm_id', $cvterm->cvterm_id)->execute();
     foreach ($term->getProperties() as $term_id => $properties) {
@@ -732,12 +735,12 @@ class ChadoIdSpace extends TripalIdSpaceBase {
           ->execute();
       }
     }
-    
+
     // Add in the alternate IDs.
     $this->chado->delete('1:cvterm_dbxref')->condition('cvterm_id', $cvterm->cvterm_id)->execute();
     foreach ($term->getAltIds() as $term_id) {
       $alt_dbxref = $this->getChadoDBXrefbyTermID($term_id);
-      if (!$alt_dbxref) {      
+      if (!$alt_dbxref) {
         $alt_dbxref = $this->insertChadoDBxrefbyTermID($term_id);
         if (!$alt_dbxref) {
           return False;
@@ -750,7 +753,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
         ])
         ->execute();
     }
-    
+
     // Add in the parents.
     $this->chado->delete('1:cvterm_relationship')->condition('subject_id', $cvterm->cvterm_id)->execute();
     foreach ($term->getParents() as $term_id => $tuple) {
@@ -771,30 +774,30 @@ class ChadoIdSpace extends TripalIdSpaceBase {
           'object_id' => $parent_term->cvterm_id,
         ])
         ->execute();
-        
+
       // Update the parent if requested to do so.
-      if ($update_parent) {        
+      if ($update_parent) {
         $parent_idSpace = $parent_term->getIdSpaceObject();
         $parent_idSpace->saveTerm($parent_term, ['failIfExists' => $options['failIfExists']]);
       }
     }
-    
+
     return True;
   }
-  
+
   /**
    * Updates an existing term in Chado.
-   * 
-   * The term should be checked that it already exists 
+   *
+   * The term should be checked that it already exists
    * prior to execution of this function.
-   * 
+   *
    * @param Drupal\tripal\TripalVocabTerms\TripalTerm $term
    *   The term object to update
    * @param object $cvterm
    *   The record object for the term to update from the Chado cvterm table.
    * @param array $options
    *   The options passed to the saveTerm() function.
-   *   
+   *
    * @return boolean
    *   True if the update was successful, false otherwise.
    */
@@ -810,7 +813,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
         ->condition('cvterm_id', $cvterm->cvterm_id)
         ->execute();
       $cvterm = $this->getChadoCVTerm($term);
-        
+
       $this->saveTermAttributes($term, $cvterm, $options);
     }
     catch (Exception $e) {
@@ -820,14 +823,14 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     }
     return True;
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function removeTerm($accession) {
-    
+
   }
-  
+
   /**
    * {@inheritdoc}
    */
@@ -836,19 +839,19 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     if (!$db) {
       return NULL;
     }
-    return $db['urlprefix'];    
+    return $db['urlprefix'];
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function setURLPrefix($prefix) {
-    
+
     // Don't set a value for an ID space that isn't valid.
     if (!$this->is_valid) {
       return False;
     }
-    
+
     // Make sure the URL prefix is good.
     if (strlen($this->getURLPrefix()) > $this->db_def['fields']['urlprefix']['size']) {
       $this->messageLogger->error('ChadoIdSpace: The URL prefix for the vocabulary ID Space must not be longer than @size characters. ' +
@@ -857,7 +860,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
             '@value' => $this->getName()]);
       return False;
     }
-    
+
     // Update the record in the Chado `db` table.
     $query = $this->chado->update('1:db')
       ->fields(['urlprefix' => $prefix])
@@ -869,30 +872,30 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     }
     return True;
   }
-  
-  
+
+
   /**
    * {@inheritdoc}
    */
-  public function getDescription() {  
+  public function getDescription() {
     $db = $this->loadIdSpace();
     if (!$db) {
       return NULL;
     }
     return $db['description'];
-    
+
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function setDescription($description) {
-    
+
     // Don't set a value for an ID space that isn't valid.
     if (!$this->is_valid) {
       return False;
     }
-    
+
 
     // Make sure the description is not too long.
     if (strlen($this->getDescription()) > $this->db_def['fields']['description']['size']) {
@@ -902,7 +905,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
            '@value' => $this->getName()]);
       return False;
     }
-    
+
     // Update the record in the Chado `db` table.
     $query = $this->chado->update('1:db')
        ->fields(['description' => $description])
@@ -910,12 +913,38 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     $num_updated = $query->execute();
     if ($num_updated != 1) {
       $this->messageLogger->error('ChadoIdSpace: The description could not be updated for the vocabulary ID Space.');
-      return False;      
+      return False;
     }
     return True;
 
   }
-  
+
+  /**
+   * Retrieves from the Drupal cache the default vocabulary for this space..
+   *
+   * @return string
+   *   The deffault vocabulary name.
+   */
+  protected function getDefaultVocabCache() {
+    $cid = 'chado_id_space_' . $this->getName() . '_default_vocab';
+    $default_vocab = '';
+    if ($cache = \Drupal::cache()->get($cid)) {
+      $default_vocab = $cache->data;
+    }
+    return $default_vocab;
+  }
+
+  /**
+   * Sets in the Drupal cache the default vocabulary.
+   *
+   * @param string $vocabulary
+   *   The default vocabulary name.
+   */
+  protected function setDefaultVocabCache($vocabulary) {
+    $cid = 'chado_id_space_' . $this->getName() . '_default_vocab';
+    \Drupal::cache()->set($cid, $vocabulary);
+  }
+
   /**
    * {@inheritdoc}
    */
@@ -924,6 +953,7 @@ class ChadoIdSpace extends TripalIdSpaceBase {
     if ($retval === True) {
       $this->default_vocabulary = $name;
     }
+    $this->setDefaultVocabCache($name);
     return $retval;
   }
 }

--- a/tripal_chado/src/Plugin/TripalVocabulary/ChadoVocabulary.php
+++ b/tripal_chado/src/Plugin/TripalVocabulary/ChadoVocabulary.php
@@ -6,7 +6,7 @@ use Drupal\tripal\TripalVocabTerms\TripalVocabularyBase;
 
 /**
  * Chado implementation of the TripalVocabularyBase.
- * 
+ *
  *  @TripalVocabulary(
  *    id = "chado_vocabulary",
  *    label = @Translation("Vocabulary in Chado"),
@@ -17,71 +17,71 @@ class ChadoVocabulary extends TripalVocabularyBase {
    * Holds an instance of a BioDB connection to Chado.
    */
   protected $chado = NULL;
-      
+
   /**
    * The definition for the `db` table of Chado.
    */
   protected $db_def = NULL;
-  
+
   /**
    * The definition for the `cv` table of Chado.
    */
   protected $cv_def = NULL;
-  
+
   /**
    * An instance of the TripalLogger.
    */
   protected $messageLogger = NULL;
-  
+
   /**
    * A simple boolean to prevent Chado queries if the vocabulary isn't valid.
    */
   protected $is_valid = False;
-  
+
   /**
    * {@inheritdoc}
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    
+
     // Instantiate the TripalLogger
     $this->messageLogger = \Drupal::service('tripal.logger');
-    
+
     // Instantiate a TripalDBX connection for Chado.
     $this->chado = \Drupal::service('tripal_chado.database');
-    
+
     // Get the chado definition for the `cv` and `db` tables.
     $this->db_def = $this->chado->schema()->getTableDef('db', ['Source' => 'file']);
     $this->cv_def = $this->chado->schema()->getTableDef('cv', ['Source' => 'file']);
   }
-  
-  
+
+
   /**
    * {@inheritdoc}
    */
-  public function isValid() {   
-    
+  public function isValid() {
+
     // Make sure the name of this collection does not exceeed the allowed size in Chado.
     if (strlen($this->getName()) > $this->cv_def['fields']['name']['size']) {
       $this->messageLogger->error('ChadoVocabulary: The vocabulary name must not be longer than @size characters. ' +
           'The value provided was: @value',
           ['@size' => $this->cv_def['fields']['name']['size'],
            '@value' => $this->getName()]);
-          
+
     }
     $this->is_valid = True;
-    
+
     return $this->is_valid;
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function create(){
-       
+
     // Check if the record already exists in the database, if it
     // doesn't then insert it.  We don't yet have the definition,
-    // but that's okay, the name is all that isrequired to create 
+    // but that's okay, the name is all that isrequired to create
     // a record in the `cv` table.
     $vocab = $this->loadVocab();
     if (!$vocab) {
@@ -90,7 +90,7 @@ class ChadoVocabulary extends TripalVocabularyBase {
       $query->execute();
     }
   }
-  
+
   /**
    * {@inheritdoc}
    */
@@ -102,8 +102,8 @@ class ChadoVocabulary extends TripalVocabularyBase {
     // Tripal is concerned but leave the record in Chado.
     // So, do nothing here.
   }
- 
-  
+
+
   /**
    * Loads an Vocbulary record from Chado.
    *
@@ -115,7 +115,7 @@ class ChadoVocabulary extends TripalVocabularyBase {
    *   of Chado or NULL if the db could not be found.
    */
   protected function loadVocab() {
-    
+
     // Get the Chado `db` record for this ID space.
     $query = $this->chado->select('1:cv', 'cv')
       ->condition('cv.name', $this->getName(), '=')
@@ -125,24 +125,24 @@ class ChadoVocabulary extends TripalVocabularyBase {
       return $result->fetchAssoc();
     }
     return NULL;
-  }    
-    
+  }
+
   /**
    * {@inheritdoc}
    */
   public function getIdSpaceNames(){
     return $this->getIdSpacesCache();
   }
-  
+
   /**
    * Sets the ID spaces for this vocabulary in the Drupal cache.
-   * 
+   *
    * The current way to map CV's to DB's is to use the `cv2db`
    * materialized view but there is no guarantee that that mview
    * is up-to-date and it would take too long to force an update
    * every time we need to get the ID spaces for a vocabulary.  This
    * function caches it.
-   * 
+   *
    * @param $id_spaces
    *   An array containing the names of the ID spaces.
    */
@@ -150,17 +150,17 @@ class ChadoVocabulary extends TripalVocabularyBase {
     $cid = 'chado_vocabulary_' . $this->getName() . '_id_spaces';
     \Drupal::cache()->set($cid, $id_spaces);
   }
-  
+
   /**
    * Retrieves from the Drupal cache the ID spaces of this vocabulary.
-   * 
+   *
    * The current way to map CV's to DB's is to use the `cv2db`
    * materialized view but there is no guarantee that that mview
    * is up-to-date and it would take too long to force an update
    * every time we need to get the ID spaces for a vocabulary.  This
-   * function retrieves the ID spaces for a vocabulary from a 
+   * function retrieves the ID spaces for a vocabulary from a
    * Drupal cache.
-   * 
+   *
    * @return array
    *   An array of ID Space names.
    */
@@ -172,27 +172,27 @@ class ChadoVocabulary extends TripalVocabularyBase {
     }
     return $id_spaces;
   }
-  
-  
+
+
   /**
    * {@inheritdoc}
    */
   public function addIdSpace($idSpace){
-    
+
     // Get the ID collection for this idSpace and save it for future
     // reference, then add the idSpace to our list.
     $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');
     $id = $idsmanager->loadCollection($idSpace);
-    if ($id) {      
-      $id_spaces = $this->getIdSpacesCache();      
+    if ($id) {
+      $id_spaces = $this->getIdSpacesCache();
       $id_spaces[] = $idSpace;
       $this->setIdSpacesCache($id_spaces);
       return True;
     }
     return False;
   }
-  
-  
+
+
   /**
    * {@inheritdoc}
    */
@@ -211,14 +211,14 @@ class ChadoVocabulary extends TripalVocabularyBase {
     $this->setIdSpacesCache($new_ids);
     return $found;
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function getTerms($name, $exact = True){
-    
+
   }
-  
+
   /**
    * {@inheritdoc}
    */
@@ -226,15 +226,15 @@ class ChadoVocabulary extends TripalVocabularyBase {
     // Don't get a value for a vocabulary that isn't valid.
     if (!$this->is_valid) {
       return NULL;
-    }    
-    
+    }
+
     // If we don't have any ID spaces then there is no URL.
     $id_spaces = $this->getIdSpacesCache();
     if (count($id_spaces) == 0) {
-      $this->messageLogger->error('ChadoVocabulary: Cannot get the URL when no ID spaces are present for the vocabulary.');      
+      $this->messageLogger->error('ChadoVocabulary: Cannot get the URL when no ID spaces are present for the vocabulary.');
       return NULL;
     }
-    
+
     // All of the ID spaces for the vocabulary should
     // have the same URL, so only query the first corresponding
     // `db` record to get the URL.
@@ -247,29 +247,29 @@ class ChadoVocabulary extends TripalVocabularyBase {
     }
     return $db->fetchField();
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function setURL($url){
-    
+
     // @todo there may be a problem in the future if we are able to
-    // associate borrowed terms with a vocabulary in Chado.  If we 
-    // add the ID space of borrowed terms to a vocabulary then 
+    // associate borrowed terms with a vocabulary in Chado.  If we
+    // add the ID space of borrowed terms to a vocabulary then
     // setting the URL will be incorrect for those ID spaces.
-    
+
     // Don't set a value for a vocabulary that isn't valid.
     if (!$this->is_valid) {
       return False;
     }
-    
+
     // If we don't have any ID spaces then there is no URL.
     $id_spaces = $this->getIdSpacesCache();
     if (count($id_spaces) == 0) {
       $this->messageLogger->error('ChadoVocabulary: Cannot set the URL when no ID spaces are present for the vocabulary.');
       return False;
     }
-    
+
     // This value goes to the Chado `db.url` column, so check it's size
     // to make sure it doesn't exceed it.
     if (strlen($url) > $this->db_def['fields']['url']['size']) {
@@ -279,21 +279,22 @@ class ChadoVocabulary extends TripalVocabularyBase {
             '@value' => $this->getName()]);
       return False;
     }
-    
+
     // Update the record in the Chado `db` table for the URL for all ID spaces.
     foreach ($id_spaces as $name) {
       $num_updated = $this->chado->update('1:db')
         ->fields(['url' => $url])
-        ->condition('name', $name, '=')      
+        ->condition('name', $name, '=')
         ->execute();
       if ($num_updated != 1) {
-        $this->messageLogger->error('ChadoVocabulary: The URL could not be updated for the vocabulary.');
-        return False;        
+        $this->messageLogger->error(t('ChadoVocabulary: The URL could not be updated for the vocabulary, "@vocab.',
+          ['@vocab' => $this->getName()]));
+        return False;
       }
     }
     return True;
-  }  
-  
+  }
+
   /**
    * Returns the namespace of the vocabulary
    *
@@ -306,8 +307,8 @@ class ChadoVocabulary extends TripalVocabularyBase {
   public function getNameSpace() {
     return $this->getName();
   }
-  
-  
+
+
   /**
    * {@inheritdoc}
    */
@@ -316,11 +317,11 @@ class ChadoVocabulary extends TripalVocabularyBase {
     if (!$this->is_valid) {
       return False;
     }
-    
+
     // Note: there's no need to check the size of the label value
     // because the Chado column where this goes (cv.definition) is an
-    // unlimited text field.    
-    
+    // unlimited text field.
+
     // Update the record in the Chado `cv` table.
     $query = $this->chado->update('1:cv')
       ->fields(['definition' => $label])
@@ -328,12 +329,12 @@ class ChadoVocabulary extends TripalVocabularyBase {
     $num_updated = $query->execute();
     if ($num_updated != 1) {
       $this->logInvalidCondition('ChadoVocabulary: The label could not be updated for the vocabulary.');
-      return False;      
+      return False;
     }
     return True;
   }
-  
-  
+
+
   /**
    * {@inheritdoc}
    */
@@ -342,6 +343,6 @@ class ChadoVocabulary extends TripalVocabularyBase {
     if (!$cv) {
       return NULL;
     }
-    return $cv['definition'];   
+    return $cv['definition'];
   }
 }

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -179,9 +179,9 @@ class ChadoPreparer extends ChadoTaskBase {
       $this->logger->notice("Creating default content types...");
       $this->createGeneralContentTypes();
       $this->createGenomicContentTypes();
-      //$this->createGeneticContentTypes();
-      //$this->createGermplasmContentTypes();
-      //$this->createExpressionContentTypes();
+      $this->createGeneticContentTypes();
+      $this->createGermplasmContentTypes();
+      $this->createExpressionContentTypes();
 
       $this->setProgress(1);
       $task_success = TRUE;
@@ -1012,22 +1012,6 @@ class ChadoPreparer extends ChadoTaskBase {
       'definition' => 'Any extent of continuous biological sequence.',
     ]));
     //chado_associate_semweb_term(NULL, 'feature_id', $term);
-
-    $idspace->saveTerm(new TripalTerm([
-      'accession' => '0000704',
-      'name' => 'gene',
-      'idSpace' => 'SO',
-      'vocabulary' => 'sequence',
-      'definition' => '',
-    ]));
-
-    $idspace->saveTerm(new TripalTerm([
-      'accession' => '0000234',
-      'name' => 'mRNA',
-      'idSpace' => 'SO',
-      'vocabulary' => 'sequence',
-      'definition' => '',
-    ]));
   }
 
   /**
@@ -3466,77 +3450,35 @@ class ChadoPreparer extends ChadoTaskBase {
    */
   private function createGeneticContentTypes() {
 
-    // The 'Genetic Map' entity type. bio_data_16
-    $terms['map'] =[
-      'accession' => '1278',
-      'vocabulary' => [
-        'idspace' => 'data',
-      ],
-    ];
-    $types['map']= [
-      'id' => 16,
-      'name' => 'bio_data_16',
+    $this->createContentType([
       'label' => 'Genetic Map',
+      'term' => $this->getTerm('data', '1278', 'EDAM'),
       'category' => 'Genetic',
-    ];
+    ]);
 
-    // The 'QTL' entity type. bio_data_17
-    $terms['qtl'] =[
-      'accession' => '0000771',
-      'vocabulary' => [
-        'idspace' => 'SO',
-      ],
-    ];
-    $types['qtl']= [
-      'id' => 17,
-      'name' => 'bio_data_17',
+    $this->createContentType([
       'label' => 'QTL',
+      'term' => $this->getTerm('SO', '0000771'),
       'category' => 'Genetic',
-    ];
+    ]);
 
-    // The 'Sequence Variant' entity type. bio_data_18
-    $terms['variant'] =[
-      'accession' => '0001060',
-      'vocabulary' => [
-        'idspace' => 'SO',
-      ],
-    ];
-    $types['variant']= [
-      'id' => 18,
-      'name' => 'bio_data_18',
+    $this->createContentType([
       'label' => 'Sequence Variant',
+      'term' => $this->getTerm('SO', '0001060'),
       'category' => 'Genetic',
-    ];
+    ]);
 
-    // The 'Genetic Marker' entity type. bio_data_19
-    $terms['marker'] =[
-      'accession' => '0001645',
-      'vocabulary' => [
-        'idspace' => 'SO',
-      ],
-    ];
-    $types['marker']= [
-      'id' => 19,
-      'name' => 'bio_data_19',
+    $this->createContentType([
       'label' => 'Genetic Marker',
+      'term' => $this->getTerm('SO', '0001645'),
       'category' => 'Genetic',
-    ];
+    ]);
 
-    // The 'Heritable Phenotypic Marker' entity type. bio_data_20
-    $terms['hpn'] =[
-      'accession' => '0001500',
-      'vocabulary' => [
-        'idspace' => 'SO',
-      ],
-    ];
-    $types['hpn']= [
-      'id' => 20,
-      'name' => 'bio_data_20',
+    $this->createContentType([
       'label' => 'Heritable Phenotypic Marker',
+      'term' => $this->getTerm('SO', '0001500'),
       'category' => 'Genetic',
-    ];
-
-    $this->createGivenContentTypes($types, $terms);
+    ]);
   }
 
   /**
@@ -3544,78 +3486,35 @@ class ChadoPreparer extends ChadoTaskBase {
    */
   private function createGermplasmContentTypes() {
 
-    // The 'Phenotypic Trait' entity type. bio_data_28
-    $terms['trait'] =[
-      'accession' => 'C85496',
-      'vocabulary' => [
-        'idspace' => 'NCIT',
-      ],
-    ];
-    $types['trait']= [
-      'id' => 28,
-      'name' => 'bio_data_28',
+    $this->createContentType([
       'label' => 'Phenotypic Trait',
+      'term' => $this->getTerm('NCIT', 'C85496'),
       'category' => 'Germplasm',
-    ];
+    ]);
 
-    // The 'Germplasm Accession' entity type. bio_data_21
-    $terms['accession'] = [
-      'accession' => '0000044',
-      'vocabulary' => [
-        'namespace' => 'germplasm_ontology',
-        'idspace' => 'CO_010',
-      ],
-    ];
-    $types['accession'] = [
-      'id' => 21,
-      'name' => 'bio_data_21',
+    $this->createContentType([
       'label' => 'Germplasm Accession',
+      'term' => $this->getTerm('CO_010', '0000044'),
       'category' => 'Germplasm',
-    ];
+    ]);
 
-    // The 'Breeding Cross' entity type. bio_data_22
-    $terms['cross'] =[
-      'accession' => '0000255',
-      'vocabulary' => [
-        'idspace' => 'CO_010',
-      ],
-    ];
-    $types['cross']= [
-      'id' => 22,
-      'name' => 'bio_data_22',
+    $this->createContentType([
       'label' => 'Breeding Cross',
+      'term' => $this->getTerm('CO_010', '0000255'),
       'category' => 'Germplasm',
-    ];
+    ]);
 
-    // The 'Germplasm Variety' entity type. bio_data_23
-    $terms['variety'] =[
-      'accession' => '0000029',
-      'vocabulary' => [
-        'idspace' => 'CO_010',
-      ],
-    ];
-    $types['variety']= [
-      'id' => 23,
-      'name' => 'bio_data_23',
+    $this->createContentType([
       'label' => 'Germplasm Variety',
+      'term' => $this->getTerm('CO_010', '0000029'),
       'category' => 'Germplasm',
-    ];
+    ]);
 
-    // The 'Recombinant Inbred Line' entity type. bio_data_24
-    $terms['ril'] =[
-      'accession' => '0000162',
-      'vocabulary' => [
-        'idspace' => 'CO_010',
-      ],
-    ];
-    $types['ril']= [
-      'id' => 24,
-      'name' => 'bio_data_24',
+    $this->createContentType([
       'label' => 'Recombinant Inbred Line',
+      'term' => $this->getTerm('CO_010', '0000162'),
       'category' => 'Germplasm',
-    ];
-
-    $this->createGivenContentTypes($types, $terms);
+    ]);
   }
 
   /**
@@ -3623,48 +3522,22 @@ class ChadoPreparer extends ChadoTaskBase {
    */
   private function createExpressionContentTypes() {
 
-    // The 'biological sample' entity type. bio_data_25
-    $terms['sample'] =[
-      'accession' => '00195',
-      'vocabulary' => [
-        'idspace' => 'sep',
-      ],
-    ];
-    $types['sample']= [
-      'id' => 25,
-      'name' => 'bio_data_25',
+    $this->createContentType([
       'label' => 'Biological Sample',
+      'term' => $this->getTerm('sep', '00195'),
       'category' => 'Expression',
-    ];
+    ]);
 
-    // The 'Assay' entity type. bio_data_26
-    $terms['assay'] =[
-      'accession' => '0000070',
-      'vocabulary' => [
-        'idspace' => 'OBI',
-      ],
-    ];
-    $types['assay']= [
-      'id' => 26,
-      'name' => 'bio_data_26',
+    $this->createContentType([
       'label' => 'Assay',
+      'term' => $this->getTerm('OBI', '0000070'),
       'category' => 'Expression',
-    ];
+    ]);
 
-    // The 'Array Design' entity type. bio_data_27
-    $terms['design'] =[
-      'accession' => '0000269',
-      'vocabulary' => [
-        'idspace' => 'EFO',
-      ],
-    ];
-    $types['design']= [
-      'id' => 27,
-      'name' => 'bio_data_27',
+    $this->createContentType([
       'label' => 'Array Design',
+      'term' => $this->getTerm('EFO', '0000269'),
       'category' => 'Expression',
-    ];
-
-    $this->createGivenContentTypes($types, $terms);
+    ]);
   }
 }

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -1523,7 +1523,7 @@ class ChadoPreparer extends ChadoTaskBase {
     $data_idspace = $this->getIdSpace('data');
     $data_idspace->setDescription("Bioinformatics operations, data types, formats, identifiers and topics.");
     $data_idspace->setURLPrefix("http://edamontology.org/{db}_{accession}");
-    $data_idspace->setDefaultVocabulary('foaf');
+    $data_idspace->setDefaultVocabulary('EDAM');
 
     $format_idspace = $this->getIdSpace('format');
     $format_idspace->setDescription('A defined way or layout of representing and structuring data in a computer file, blob, string, message, or elsewhere. The main focus in EDAM lies on formats as means of structuring data exchanged between different tools or resources.');

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -1538,7 +1538,7 @@ class ChadoPreparer extends ChadoTaskBase {
     $topic_idspace = $this->getIdSpace('topic');
     $topic_idspace->setDescription('A category denoting a rather broad domain or field of interest, of study, application, work, data, or technology. Topics have no clearly defined borders between each other.');
     $topic_idspace->setURLPrefix("http://edamontology.org/{db}_{accession}");
-    $topic_idspace->setDefaultVocabulary('foaf');
+    $topic_idspace->setDefaultVocabulary('EDAM');
 
     $vocab->addIdSpace('data');
     $vocab->addIdSpace('format');

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -3294,6 +3294,12 @@ class ChadoPreparer extends ChadoTaskBase {
   /**
    * Create a new Content Type.
    *
+   * @param array $details
+   *   Describes the content type you would like to create.
+   *   Should contain the following:
+   *    - label: the human-readable label to be used for the content type.
+   *    - category: a human-readable category to group like content types together.
+   *    - term: a tripal term object which should be associated with the content type.
    */
   private function createContentType($details) {
 

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -3333,7 +3333,7 @@ class ChadoPreparer extends ChadoTaskBase {
       \Drupal::cache()->set($cid, $next_index);
     }
     else {
-      $this->logger->error(t('Creation of content type, "@type", failed. The provided provided were: ',
+      $this->logger->error(t('Creation of content type, "@type", failed. The provided details were: ',
           ['@type' => $details['label']]) . print_r($details));
     }
   }

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -1533,7 +1533,7 @@ class ChadoPreparer extends ChadoTaskBase {
     $operation_idspace = $this->getIdSpace('operation');
     $operation_idspace->setDescription('A function that processes a set of inputs and results in a set of outputs, or associates arguments (inputs) with values (outputs). Special cases are: a) An operation that consumes no input (has no input arguments).');
     $operation_idspace->setURLPrefix("http://edamontology.org/{db}_{accession}");
-    $operation_idspace->setDefaultVocabulary('foaf');
+    $operation_idspace->setDefaultVocabulary('EDAM');
 
     $topic_idspace = $this->getIdSpace('topic');
     $topic_idspace->setDescription('A category denoting a rather broad domain or field of interest, of study, application, work, data, or technology. Topics have no clearly defined borders between each other.');

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -155,7 +155,9 @@ class ChadoPreparer extends ChadoTaskBase {
 
       $this->setProgress(0.2);
       $this->logger->notice("Loading ontologies...");
-      $this->loadOntologies();
+      $this->addOntologies();
+      $this->logger->notice('!!!! Uncomment the importOntologies() function !!!');
+      //$this->importOntologies();
 
       $this->setProgress(0.3);
       $this->logger->notice('Populating materialized view cv_root_mview...');
@@ -175,7 +177,11 @@ class ChadoPreparer extends ChadoTaskBase {
 
       $this->setProgress(0.7);
       $this->logger->notice("Creating default content types...");
-      $this->contentTypes();
+      $this->createGeneralContentTypes();
+      $this->createGenomicContentTypes();
+      //$this->createGeneticContentTypes();
+      //$this->createGermplasmContentTypes();
+      //$this->createExpressionContentTypes();
 
       $this->setProgress(1);
       $task_success = TRUE;
@@ -895,166 +901,2371 @@ class ChadoPreparer extends ChadoTaskBase {
   }
 
   /**
-   * Loads ontologies necessary for creation of default Tripal content types.
+   * Gets a term by its idSpace and accession
+   *
+   * @param string $idSpace
+   *   The Id space name for the term.
+   * @param string $accession
+   *   The accession for the term.
+   * @return TripalTerm|NULL
+   *   A tripal term object.
    */
-  protected function loadOntologies() {
+  private function getTerm($idSpace, $accession, $vocabulary = NULL) {
+    $id = $this->getIdSpace($idSpace);
+    if ($vocabulary) {
+      $id->setDefaultVocabulary($vocabulary);
+    }
+    return $id->getTerm($accession);
+  }
 
-    $ontologies = [];
+  /**
+   * Adds the rdfs vocabulary and IdSpace.
+   */
+  private function addOntologyRDFS() {
+    $vocab = $this->getVocabulary('rdfs');
+    $vocab->setLabel('Resource Description Framework Schema');
+    $idspace = $this->getIdSpace('rdfs');
+    $idspace->setDescription('Resource Description Framework Schema');
+    $idspace->setUrlPrefix('http://www.w3.org/2000/01/rdf-schema#{accession}');
+    $idspace->setDefaultVocabulary('rdfs');
+    $vocab->addIdSpace('rdfs');
+    $vocab->setUrl('https://www.w3.org/TR/rdf-schema/');
 
-    // NCIT
-    $ncit_vocab = $this->getVocabulary('ncit');
-    $ncit_vocab->setLabel('NCI Thesaurus OBO Edition');
-    $ncit_idspace = $this->getIdSpace('NCIT');
-    $ncit_idspace->setDescription('The NCIt is a reference terminology that includes broad coverage of the cancer domain, including cancer related diseases, findings and abnormalities. NCIt OBO Edition releases should be considered experimental.');
-    $ncit_idspace->setUrlPrefix('http://purl.obolibrary.org/obo/{db}_{accession}');
-    $ncit_idspace->setDefaultVocabulary('ncit');
-    $ncit_vocab->addIdSpace('NCIT');
-    $ncit_vocab->setUrl('http://purl.obolibrary.org/obo/ncit.owl');
-    $ncit__subgroup = new TripalTerm([
-      'name' => 'Subgroup',
-      'idSpace' => 'NCIT',
-      'vocabulary' => 'ncit',
-      'accession' => 'C25693',
-      'definition' => 'A subdivision of a larger group with members often exhibiting similar characteristics. [ NCI ]',
-    ]);
-    $ncit_idspace->saveTerm($ncit__subgroup);
-
-    // RDFS
-    $rdfs_vocab = $this->getVocabulary('rdfs');
-    $rdfs_vocab->setLabel('Resource Description Framework Schema');
-    $rdfs_idspace = $this->getIdSpace('rdfs');
-    $rdfs_idspace->setDescription('Resource Description Framework Schema');
-    $rdfs_idspace->setUrlPrefix('http://www.w3.org/2000/01/rdf-schema#{accession}');
-    $rdfs_idspace->setDefaultVocabulary('rdfs');
-    $rdfs_vocab->addIdSpace('rdfs');
-    $rdfs_vocab->setUrl('https://www.w3.org/TR/rdf-schema/');
-    $rdfs__comment = new TripalTerm([
+    $idspace->saveTerm(new TripalTerm([
       'name' => 'comment',
       'accession' => 'comment',
       'idSpace' => 'rdfs',
       'vocabulary' => 'rdfs',
-      'definition' => 'A human-readable description of a resource\'s name.',
-    ]);
-    $rdfs_idspace->saveTerm($rdfs__comment);
+      'definition' => 'A human-readable description of a resource.',
+    ]));
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'type',
+      'accession' => 'type',
+      'idSpace' => 'rdfs',
+      'vocabulary' => 'rdfs',
+      'definition' => 'The type of resource.',
+    ]));
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'label',
+      'accession' => 'label',
+      'idSpace' => 'rdfs',
+      'vocabulary' => 'rdfs',
+      'definition' => 'A human-readable version of a resource\'s name.',
+    ]));
 
-    // RO
-    $rel_vocab = $this->getVocabulary('ro');
-    $rel_vocab->setLabel('Relationship Ontology (legacy)');
-    $RO_idspace = $this->getIdSpace('RO');
-    $RO_idspace->setDescription('Relationship Ontology (legacy)');
-    $RO_idspace->setURLPrefix("cv/lookup/RO/{accession}	");
-    $RO_idspace->setDefaultVocabulary('ro');
-    $rel_vocab->addIdSpace('RO');
-    $rel_vocab->setUrl('cv/lookup/RO');
-    $ontologies[] = [
-      'vocabulary' => $rel_vocab,
-      'idSpace' => $RO_idspace,
-      'path' => '{tripal_chado}/files/legacy_ro.obo',
-      'auto_load' => FALSE,
-    ];
+  }
 
-    // GO
+  /**
+   * Adds the relationship ontology vocabulary and IdSpace.
+   */
+  private function addOntologyRO() {
+    $vocab = $this->getVocabulary('ro');
+    $vocab->setLabel('Relationship Ontology (legacy)');
+    $idspace = $this->getIdSpace('RO');
+    $idspace->setDescription('Relationship Ontology (legacy)');
+    $idspace->setURLPrefix("cv/lookup/RO/{accession}	");
+    $idspace->setDefaultVocabulary('ro');
+    $vocab->addIdSpace('RO');
+    $vocab->setUrl('cv/lookup/RO');
+  }
+
+  /**
+   * Adds the Gene Ontology vocabulary and IdSpace.
+   */
+  private function addOntologyGO() {
     $cc_vocab = $this->getVocabulary('cellular_component');
     $bp_vocab = $this->getVocabulary('biological_process');
     $mf_vocab = $this->getVocabulary('molecular_function');
     $cc_vocab->setLabel('Gene Ontology Cellular Component Vocabulary');
     $bp_vocab->setLabel('Gene Ontology Biological Process Vocabulary');
     $mf_vocab->setLabel('Gene Ontology Molecular Function Vocabulary');
-    $GO_idspace = $this->getIdSpace('GO');
-    $GO_idspace->setDescription("The Gene Ontology (GO) knowledgebase is the world’s largest source of information on the functions of genes");
-    $GO_idspace->setURLPrefix("http://amigo.geneontology.org/amigo/term/{db}:{accession}");
-    $GO_idspace->setDefaultVocabulary('cellular_component');
+    $idspace = $this->getIdSpace('GO');
+    $idspace->setDescription("The Gene Ontology (GO) knowledgebase is the world’s largest source of information on the functions of genes");
+    $idspace->setURLPrefix("http://amigo.geneontology.org/amigo/term/{db}:{accession}");
+    $idspace->setDefaultVocabulary('cellular_component');
     $cc_vocab->addIdSpace('GO');
     $bp_vocab->addIdSpace('GO');
     $mf_vocab->addIdSpace('GO');
     $cc_vocab->setURL('http://geneontology.org/');
     $bp_vocab->setURL('http://geneontology.org/');
     $mf_vocab->setURL('http://geneontology.org/');
+  }
+
+  /**
+   * Adds the Sequence Ontology vocabulary and IdSpace.
+   */
+  private function addOntologySO() {
+    $vocab = $this->getVocabulary('sequence');
+    $vocab->setLabel('The Sequence Ontology');
+    $idspace = $this->getIdSpace('SO');
+    $idspace->setDescription("The Sequence Ontology");
+    $idspace->setURLPrefix("http://www.sequenceontology.org/browser/current_svn/term/{db}:{accession}");
+    $idspace->setDefaultVocabulary('sequence');
+    $vocab->addIdSpace('SO');
+    $vocab->setURL('http://www.sequenceontology.org');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000110',
+      'name' => 'sequence_feature',
+      'idSpace' => 'SO',
+      'vocabulary' => 'sequence',
+      'definition' => 'Any extent of continuous biological sequence.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'feature_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000704',
+      'name' => 'gene',
+      'idSpace' => 'SO',
+      'vocabulary' => 'sequence',
+      'definition' => '',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000234',
+      'name' => 'mRNA',
+      'idSpace' => 'SO',
+      'vocabulary' => 'sequence',
+      'definition' => '',
+    ]));
+  }
+
+  /**
+   * Adds the Taxonomic Rank Ontology vocabulary and IdSpace.
+   */
+  private function addOntologyTaxRank() {
+    $vocab = $this->getVocabulary('taxonomic_rank');
+    $vocab->setLabel('Taxonomic Rank');
+    $idspace = $this->getIdSpace('TAXRANK');
+    $idspace->setDescription("A vocabulary of taxonomic ranks (species, family, phylum, etc)");
+    $idspace->setURLPrefix("http://purl.obolibrary.org/obo/{db}_{accession}");
+    $idspace->setDefaultVocabulary('taxonomic_rank');
+    $vocab->addIdSpace('TAXRANK');
+    $vocab->setURL('http://www.obofoundry.org/ontology/taxrank.html');
+
+    //$term = chado_get_cvterm(['id' => 'TAXRANK:0000005']);
+    //chado_associate_semweb_term('organism', 'genus', $term);
+
+    //$term = chado_get_cvterm(['id' => 'TAXRANK:0000006']);
+    //chado_associate_semweb_term('organism', 'species', $term);
+
+    //$term = chado_get_cvterm(['id' => 'TAXRANK:0000045']);
+    //chado_associate_semweb_term('organism', 'infraspecific_name', $term);
+  }
+
+  /**
+   * Adds the Tripal Contact vocabulary and IdSpace.
+   */
+  private function addOntologyTContact() {
+    $vocab = $this->getVocabulary('tripal_contact');
+    $vocab->setLabel('Tripal Contact Ontology');
+    $idspace = $this->getIdSpace('TCONTACT');
+    $idspace->setDescription("Tripal Contact Ontology. A temporary ontology until a more formal appropriate ontology an be identified.");
+    $idspace->setURLPrefix("cv/lookup/TCONTACT/{accession}	");
+    $idspace->setDefaultVocabulary('tripal_contact');
+    $vocab->addIdSpace('TCONTACT');
+    $vocab->setURL('cv/lookup/TCONTACT');
+  }
+  /**
+   * Adds the Tripal Pub vocabulary and IdSpace..
+   */
+  private function addOntologyTPub() {
+    $vocab = $this->getVocabulary('tripal_pub');
+    $vocab->setLabel('Tripal Publication Ontology');
+    $idspace = $this->getIdSpace('TPUB');
+    $idspace->setDescription("Tripal Publication Ontology. A temporary ontology until a more formal appropriate ontology an be identified.");
+    $idspace->setURLPrefix("cv/lookup/TPUB/{accession}	");
+    $idspace->setDefaultVocabulary('tripal_pub');
+    $vocab->addIdSpace('TPUB');
+    $vocab->setURL('cv/lookup/TPUB');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000002',
+      'name' => 'Publication',
+      'idSpace' => 'TPUB',
+      'vocabulary' => 'tripal_pub',
+      'definition' => '',
+    ]));
+
+    //$term = chado_get_cvterm(['id' => 'TPUB:0000039']);
+    //chado_associate_semweb_term('pub', 'title', $term);
+
+    //$term = chado_get_cvterm(['id' => 'TPUB:0000243']);
+    //chado_associate_semweb_term('pub', 'volumetitle', $term);
+
+    //$term = chado_get_cvterm(['id' => 'TPUB:0000042']);
+    //chado_associate_semweb_term('pub', 'volume', $term);
+
+    //$term = chado_get_cvterm(['id' => 'TPUB:0000256']);
+    //chado_associate_semweb_term('pub', 'series_name', $term);
+
+    //$term = chado_get_cvterm(['id' => 'TPUB:0000043']);
+    //chado_associate_semweb_term('pub', 'issue', $term);
+
+    //$term = chado_get_cvterm(['id' => 'TPUB:0000059']);
+    //chado_associate_semweb_term('pub', 'pyear', $term);
+
+    //$term = chado_get_cvterm(['id' => 'TPUB:0000044']);
+    //chado_associate_semweb_term('pub', 'pages', $term);
+
+    //$term = chado_get_cvterm(['id' => 'TPUB:0000244']);
+    //chado_associate_semweb_term('pub', 'publisher', $term);
+
+    //$term = chado_get_cvterm(['id' => 'TPUB:0000245']);
+    //chado_associate_semweb_term('pub', 'pubplace', $term);
+  }
+
+  /**
+   * Adds the friend of a friend database and terms.
+   */
+  private function addOntologyFOAF() {
+    $vocab = $this->getVocabulary('foaf');
+    $vocab->setLabel('Friend of a Friend. A dictionary of people-related terms that can be used in structured data).');
+    $idspace = $this->getIdSpace('foaf');
+    $idspace->setDescription("Friend of a Friend");
+    $idspace->setURLPrefix("http://xmlns.com/foaf/spec/#");
+    $idspace->setDefaultVocabulary('foaf');
+    $vocab->addIdSpace('foaf');
+    $vocab->setURL('http://www.foaf-project.org/');
+  }
+
+  /**
+   * Adds the Hydra vocabulary
+   */
+  private function addOntologyHydra() {
+
+    $vocab = $this->getVocabulary('hydra');
+    $vocab->setLabel('A Vocabulary for Hypermedia-Driven Web APIs.');
+    $idspace = $this->getIdSpace('hydra');
+    $idspace->setDescription("A Vocabulary for Hypermedia-Driven Web APIs");
+    $idspace->setURLPrefix("http://www.w3.org/ns/hydra/core#{accession}");
+    $idspace->setDefaultVocabulary('hydra');
+    $vocab->addIdSpace('hydra');
+    $vocab->setURL('http://www.w3.org/ns/hydra/core');
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Collection',
+      'accession' => 'Collection',
+      'idSpace' => 'hydra',
+      'vocabulary' => 'hydra',
+      'definition' => 'A collection holding references to a number of related resources.',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'member',
+      'accession' => 'member',
+      'idSpace' => 'hydra',
+      'vocabulary' => 'hydra',
+      'definition' => 'A member of the collection',
+    ]));
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'description',
+      'accession' => 'description',
+      'idSpace' => 'hydra',
+      'vocabulary' => 'hydra',
+      'definition' => 'A description.',
+    ]));
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'totalItems',
+      'accession' => 'totalItems',
+      'idSpace' => 'hydra',
+      'vocabulary' => 'hydra',
+      'definition' => 'The total number of items referenced by a collection.',
+    ]));
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'title',
+     'accession' => 'title',
+      'idSpace' => 'hydra',
+      'vocabulary' => 'hydra',
+      'definition' => 'A title, often used along with a description.',
+    ]));
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'PartialCollectionView',
+      'name' => 'PartialCollectionView',
+      'idSpace' => 'hydra',
+      'vocabulary' => 'hydra',
+      'definition' => 'A PartialCollectionView describes a partial view of a Collection. Multiple PartialCollectionViews can be connected with the the next/previous properties to allow a client to retrieve all members of the collection.',
+    ]));
+  }
+
+  /**
+   * Adds the RDFS database and terms.
+   */
+  private function addOntologyRDF() {
+    $vocab = $this->getVocabulary('rdf');
+    $vocab->setLabel('Resource Description Framework');
+    $idspace = $this->getIdSpace('rdf');
+    $idspace->setDescription("Resource Description Framework");
+    $idspace->setURLPrefix("http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+    $idspace->setDefaultVocabulary('rdf');
+    $vocab->addIdSpace('rdf');
+    $vocab->setURL('http://www.w3.org/1999/02/22-rdf-syntax-ns');
+  }
+
+  /**
+   * Adds the Schema.org database and terms.
+   */
+  private function addOntologySchema() {
+
+    $vocab = $this->getVocabulary('schema');
+    $vocab->setLabel('Schema.org. Schema.org is sponsored by Google, Microsoft, Yahoo and Yandex. The vocabularies are developed by an open community process.');
+    $idspace = $this->getIdSpace('schema');
+    $idspace->setDescription("Schema.org");
+    $idspace->setURLPrefix("https://schema.org/{accession}");
+    $idspace->setDefaultVocabulary('schema');
+    $vocab->addIdSpace('schema');
+    $vocab->setURL('https://schema.org/');
+
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'name',
+      'name' => 'name',
+      'idSpace' => 'schema',
+      'vocabulary' => 'schema',
+      'definition' => 'The name of the item.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'name', $term);
+    //chado_associate_semweb_term('analysis', 'sourcename', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'alternateName',
+      'name' => 'alternateName',
+      'idSpace' => 'schema',
+      'vocabulary' => 'schema',
+      'definition' => 'An alias for the item.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'synonym_id', $term);
+    //chado_associate_semweb_term('cvtermsynonym', 'synonym', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'comment',
+      'name' => 'comment',
+      'idSpace' => 'schema',
+      'vocabulary' => 'schema',
+      'definition' => 'Comments, typically from users.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'comment', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'description',
+      'name' => 'description',
+      'idSpace' => 'schema',
+      'vocabulary' => 'schema',
+      'definition' => 'A description of the item.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'description', $term);
+    //chado_associate_semweb_term('organism', 'comment', $term);
+    //chado_associate_semweb_term('protocol', 'protocoldescription', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'publication',
+      'name' => 'publication',
+      'idSpace' => 'schema',
+      'vocabulary' => 'schema',
+      'definition' => 'A publication event associated with the item.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'pub_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'url',
+      'name' => 'url',
+      'idSpace' => 'schema',
+      'vocabulary' => 'schema',
+      'definition' => 'URL of the item.',
+    ]));
+    //chado_associate_semweb_term('db', 'url', $term);
+
+    // Typically the type_id field is used for distinguishing between records
+    // but in the case that it isn't then we need to associate a term with it
+    // An entity already has a type so if that type is not dicated by the
+    // type_id field then what is in the type_id should therefore be an
+    // "additionalType".  Therefore we need to add and map this term to all
+    // of the appropriate type_id fields.
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'additionalType',
+      'name' => 'additionalType',
+      'idSpace' => 'schema',
+      'vocabulary' => 'schema',
+      'definition' => 'An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in.',
+    ]));
+//     $tables = chado_get_table_names(TRUE);
+//     foreach ($tables as $table) {
+//       $schema = chado_get_schema($table);
+//       // The type_id for the organism is infraspecific type, so don't make
+//       // the association for that type.
+//       if ($table == 'organism') {
+//         continue;
+//       }
+//       if (in_array("type_id", array_keys($schema['fields']))) {
+//         //chado_associate_semweb_term($table, 'type_id', $term);
+//       }
+//     }
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'ItemPage',
+      'name' => 'ItemPage',
+      'idSpace' => 'schema',
+      'vocabulary' => 'schema',
+      'definition' => 'A page devoted to a single item, such as a particular product or hotel.',
+    ]));
+  }
+
+  /**
+   * Adds the Sample processing and separation techniques database and terms.
+   */
+  private function addOntologySEP() {
+
+    $vocab = $this->getVocabulary('sep');
+    $vocab->setLabel('A structured controlled vocabulary for the annotation of sample processing and separation techniques in scientific experiments.');
+    $idspace = $this->getIdSpace('sep');
+    $idspace->setDescription("Sample processing and separation techniques.");
+    $idspace->setURLPrefix("http://purl.obolibrary.org/obo/{db}_{accession}");
+    $idspace->setDefaultVocabulary('sep');
+    $vocab->addIdSpace('sep');
+    $vocab->setURL('http://psidev.info/index.php?q=node/312');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '00195',
+      'name' => 'biological sample',
+      'idSpace' => 'sep',
+      'vocabulary' => 'sep',
+      'definition' => 'A biological sample analysed by a particular technology.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'biomaterial_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '00101',
+      'name' => 'protocol',
+      'idSpace' => 'sep',
+      'vocabulary' => 'sep',
+      'definition' => 'A protocol is a process which is a parameterizable description of a process.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'protocol_id', $term);
+    //chado_associate_semweb_term(NULL, 'nd_protocol_id', $term);
+  }
+
+  /**
+   * Adds the SemanticScience database and terms.
+   */
+  private function addOntologySIO() {
+
+    $vocab = $this->getVocabulary('SIO');
+    $vocab->setLabel('The Semanticscience Integrated Ontology (SIO) provides a simple, integrated ontology of types and relations for rich description of objects, processes and their attributes.');
+    $idspace = $this->getIdSpace('SIO');
+    $idspace->setDescription("Semanticscience Integrated Ontology");
+    $idspace->setURLPrefix("http://semanticscience.org/resource/{db}_{accession}");
+    $idspace->setDefaultVocabulary('SIO');
+    $vocab->addIdSpace('SIO');
+    $vocab->setURL('http://sio.semanticscience.org/');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '000493',
+      'name' => 'clause',
+      'idSpace' => 'SIO',
+      'vocabulary' => 'SIO',
+      'definition' => 'A clause consists of a subject and a predicate.',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '000631',
+      'name' => 'references',
+      'idSpace' => 'SIO',
+      'vocabulary' => 'SIO',
+      'definition' => 'references is a relation between one entity and the entity that it makes reference to by name, but is not described by it.',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '000056',
+      'name' => 'position',
+      'idSpace' => 'SIO',
+      'vocabulary' => 'SIO',
+      'definition' => 'A measurement of a spatial location relative to a frame of reference or other objects.',
+    ]));
+    //chado_associate_semweb_term('featurepos', 'mappos', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '001166',
+      'name' => 'annotation',
+      'idSpace' => 'SIO',
+      'vocabulary' => 'SIO',
+      'definition' => 'An annotation is a written explanatory or critical description, or other in-context information (e.g., pattern, motif, link), that has been associated with data or other types of information.',
+    ]));
+    //chado_associate_semweb_term('feature_cvterm', 'cvterm_id', $term);
+    //chado_associate_semweb_term('analysis_cvterm', 'cvterm_id', $term);
+    //chado_associate_semweb_term('cell_line_cvterm', 'cvterm_id', $term);
+    //chado_associate_semweb_term('environment_cvterm', 'cvterm_id', $term);
+    //chado_associate_semweb_term('expression_cvterm', 'cvterm_id', $term);
+    //chado_associate_semweb_term('library_cvterm', 'cvterm_id', $term);
+    //chado_associate_semweb_term('organism_cvterm', 'cvterm_id', $term);
+    //chado_associate_semweb_term('phenotype_cvterm', 'cvterm_id', $term);
+    //chado_associate_semweb_term('stock_cvterm', 'cvterm_id', $term);
+    //chado_associate_semweb_term('stock_relationship_cvterm', 'cvterm_id', $term);
+
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '000281',
+      'name' => 'negation',
+      'idSpace' => 'SIO',
+      'vocabulary' => 'SIO',
+      'definition' => 'NOT is a logical operator in that has the value true if its operand is false.',
+    ]));
+    //chado_associate_semweb_term('feature_cvterm', 'is_not', $term);
+    //chado_associate_semweb_term('analysis_cvterm', 'is_not', $term);
+    //chado_associate_semweb_term('organism_cvterm', 'is_not', $term);
+    //chado_associate_semweb_term('stock_cvterm', 'is_not', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '001080',
+      'name' => 'vocabulary',
+      'idSpace' => 'SIO',
+      'vocabulary' => 'SIO',
+      'definition' => 'A vocabulary is a collection of terms.',
+    ]));
+    //chado_associate_semweb_term('cvterm', 'cv_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '001323',
+      'name' => 'email address',
+      'idSpace' => 'SIO',
+      'vocabulary' => 'SIO',
+      'definition' => 'an email address is an identifier to send mail to particular electronic mailbox.',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '001007',
+      'name' => 'assay',
+      'vocabulary' => 'SIO',
+      'idSpace' => 'SIO',
+      'definition' => 'An assay is an investigative (analytic) procedure in ' .
+        'laboratory medicine, pharmacology, environmental biology, and ' .
+        'molecular biology for qualitatively assessing or quantitatively ' .
+        'measuring the presence or amount or the functional activity of a ' .
+        'target entity (the analyte) which can be a drug or biochemical ' .
+        'substance or a cell in an organism or organic sample.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'assay_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '010054',
+      'name' => 'cell line',
+      'idSpace' => 'SIO',
+      'vocabulary' => 'SIO',
+      'definition' => 'A cell line is a collection of genetically identifical cells.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'cell_line_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '001066',
+      'name' => 'study',
+      'idSpace' => 'SIO',
+      'vocabulary' => 'SIO',
+      'definition' => 'A study is a process that realizes the steps of a study design.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'study_id', $term);
+  }
+
+  /**
+   * Adds the Crop Ontology terms.
+   */
+  private function addOntologyCO010() {
+    $vocab = $this->getVocabulary('germplasm_ontology');
+    $vocab->setLabel('GCP germplasm ontology');
+    $idspace = $this->getIdSpace('CO_010');
+    $idspace->setDescription('Crop Germplasm Ontology');
+    $idspace->setUrlPrefix('http://www.cropontology.org/terms/CO_010:{accession}');
+    $idspace->setDefaultVocabulary('germplasm_ontology');
+    $vocab->addIdSpace('CO_010');
+    $vocab->setUrl('http://www.cropontology.org/get-ontology/CO_010');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000044',
+      'name' => 'accession',
+      'idSpace' => 'CO_010',
+      'vocabulary' => 'germplasm_ontology',
+      'definition' => '',
+    ]));
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000255',
+      'name' => 'generated germplasm',
+      'idSpace' => 'CO_010',
+      'vocabulary' => 'germplasm_ontology',
+      'definition' => '',
+    ]));
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000029',
+      'name' => 'cultivar',
+      'idSpace' => 'CO_010',
+      'vocabulary' => 'germplasm_ontology',
+      'definition' => '',
+    ]));
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000162',
+      'name' => '414 inbred line',
+      'idSpace' => 'CO_010',
+      'vocabulary' => 'germplasm_ontology',
+      'definition' => '',
+    ]));
+  }
+
+  /**
+   * Adds the DC database.
+   */
+  private function addOntologyDC() {
+    $vocab = $this->getVocabulary('dc');
+    $vocab->setLabel('DCMI Metadata Terms');
+    $idspace = $this->getIdSpace('dc');
+    $idspace->setDescription('DCMI Metadata Terms');
+    $idspace->setUrlPrefix('http://purl.org/dc/terms/{accession}');
+    $idspace->setDefaultVocabulary('dc');
+    $vocab->addIdSpace('dc');
+    $vocab->setUrl('http://purl.org/dc/dcmitype/');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'Service',
+      'name' => 'Service',
+      'idSpace' => 'dc',
+      'vocabulary' => 'dc',
+      'definition' => 'A system that provides one or more functions.',
+    ]));
+  }
+
+  /**
+   * Adds the EDAM database and terms.
+   */
+  private function addOntologyEDAM() {
+
+    $vocab = $this->getVocabulary('EDAM');
+    $vocab->setLabel('Bioscientific data analysis ontology');
+
+    $data_idspace = $this->getIdSpace('data');
+    $data_idspace->setDescription("Bioinformatics operations, data types, formats, identifiers and topics.");
+    $data_idspace->setURLPrefix("http://edamontology.org/{db}_{accession}");
+    $data_idspace->setDefaultVocabulary('foaf');
+
+    $format_idspace = $this->getIdSpace('format');
+    $format_idspace->setDescription('A defined way or layout of representing and structuring data in a computer file, blob, string, message, or elsewhere. The main focus in EDAM lies on formats as means of structuring data exchanged between different tools or resources.');
+    $format_idspace->setURLPrefix("http://edamontology.org/{db}_{accession}");
+    $format_idspace->setDefaultVocabulary('foaf');
+
+    $operation_idspace = $this->getIdSpace('operation');
+    $operation_idspace->setDescription('A function that processes a set of inputs and results in a set of outputs, or associates arguments (inputs) with values (outputs). Special cases are: a) An operation that consumes no input (has no input arguments).');
+    $operation_idspace->setURLPrefix("http://edamontology.org/{db}_{accession}");
+    $operation_idspace->setDefaultVocabulary('foaf');
+
+    $topic_idspace = $this->getIdSpace('topic');
+    $topic_idspace->setDescription('A category denoting a rather broad domain or field of interest, of study, application, work, data, or technology. Topics have no clearly defined borders between each other.');
+    $topic_idspace->setURLPrefix("http://edamontology.org/{db}_{accession}");
+    $topic_idspace->setDefaultVocabulary('foaf');
+
+    $vocab->addIdSpace('data');
+    $vocab->addIdSpace('format');
+    $vocab->addIdSpace('operation');
+    $vocab->addIdSpace('data');
+    $vocab->setURL('http://edamontology.org/page');
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '1249',
+      'name' => 'Sequence length',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'The size (length) of a sequence, subsequence or region in a sequence, or range(s) of lengths.',
+    ]));
+    //chado_associate_semweb_term('feature', 'seqlen', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '2190',
+      'name' => 'Sequence checksum',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A fixed-size datum calculated (by using a hash function) for a molecular sequence, typically for purposes of error detection or indexing.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'md5checksum', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '2091',
+      'name' => 'Accession',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A persistent (stable) and unique identifier, typically identifying an object (entry) from a database.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'dbxref_id', $term);
+    //chado_associate_semweb_term('dbxref', 'accession', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '2044',
+      'name' => 'Sequence',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'One or more molecular sequences, possibly with associated annotation.',
+    ]));
+    //chado_associate_semweb_term('feature', 'residues', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => ':0849',
+      'name' => 'Sequence record',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A molecular sequence and associated metadata.',
+    ]));
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '0842',
+      'name' => 'Identifier',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A text token, number or something else which identifies an entity, but which may not be persistent (stable) or unique (the same identifier may identify multiple things).',
+    ]));
+    //chado_associate_semweb_term(NULL, 'uniquename', $term);
+    //chado_associate_semweb_term('assay', 'arrayidentifier', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '2976',
+      'name' => 'Protein sequence',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'One or more protein sequences, possibly with associated annotation.',
+    ]));
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '2968',
+      'name' => 'Image',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'Biological or biomedical data has been rendered into an image, typically for display on screen.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'eimage_id', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '1274',
+      'name' => 'Map',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A map of (typically one) DNA sequence annotated with positional or non-positional features.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'featuremap_id', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '1278',
+      'name' => 'Genetic map',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A map showing the relative positions of genetic markers in a nucleic acid sequence, based on estimation of non-physical distance such as recombination frequencies.',
+    ]));
+    //chado_associate_semweb_term('featuremap', 'featuremap_id', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '1280',
+      'name' => 'Physical map',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A map of DNA (linear or circular) annotated with physical features or landmarks such as restriction sites, cloned DNA fragments, genes or genetic markers, along with the physical distances between them. Distance in a physical map is measured in base pairs. A physical map might be ordered relative to a reference map (typically a genetic map) in the process of genome sequencing.',
+    ]));
+    //chado_associate_semweb_term('featuremap', 'featuremap_id', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '2012',
+      'name' => 'Sequence coordinates',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A position in a map (for example a genetic map), either a single position (point) or a region / interval.',
+    ]));
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '1056',
+      'name' => 'Database name',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'The name of a biological or bioinformatics database.',
+    ]));
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '1048',
+      'name' => 'Database ID',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'An identifier of a biological or bioinformatics database.',
+    ]));
+    //chado_associate_semweb_term('db', 'name', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '1047',
+      'name' => 'URI',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'The name of a biological or bioinformatics database.',
+    ]));
+    //chado_associate_semweb_term('analysis', 'sourceuri', $term);
+    //chado_associate_semweb_term(NULL, 'uri', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '2336',
+      'name' => 'Translation phase specification',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'Phase for translation of DNA (0, 1 or 2) relative to a fragment of the coding sequence.',
+    ]));
+    //chado_associate_semweb_term('featureloc', 'phase', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '0853',
+      'name' => 'DNA sense specification',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'The strand of a DNA sequence (forward or reverse).',
+    ]));
+    //chado_associate_semweb_term('featureloc', 'strand', $term);
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '3002',
+      'name' => 'Annotation track',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'Annotation of one particular positional feature on a ' .
+        'biomolecular (typically genome) sequence, suitable for import and ' .
+        'display in a genome browser. Synonym: Sequence annotation track.',
+    ]));
+    ////chado_associate_semweb_term('featureloc', 'srcfeature_id', $term);
+
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '0872',
+      'name' => 'Phylogenetic tree',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'The raw data (not just an image) from which a phylogenetic tree is directly generated or plotted, such as topology, lengths (in time or in expected amounts of variance) and a confidence interval for each length.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'phylotree_id', $term);
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '3272',
+      'name' => 'Species tree',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A phylogenetic tree that reflects phylogeny of the taxa from which the characters (used in calculating the tree) were sampled.',
+    ]));
+    $data_idspace->saveTerm(new TripalTerm([
+      'accession' => '3271',
+      'name' => 'Gene tree',
+      'idSpace' => 'data',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A phylogenetic tree that is an estimate of the character\'s phylogeny.',
+    ]));
+    $operation_idspace->saveTerm(new TripalTerm([
+      'accession' => '0567',
+      'name' => 'Phylogenetic tree visualisation',
+      'idSpace' => 'operation',
+      'vocabulary' => 'EDAM',
+      'definition' => 'A phylogenetic tree that is an estimate of the character\'s phylogeny.',
+    ]));
+    $operation_idspace->saveTerm(new TripalTerm([
+      'accession' => '0564',
+      'name' => 'Sequence visualisation',
+      'idSpace' => 'operation',
+      'vocabulary' => 'EDAM',
+      'definition' => 'Visualise, format or render a molecular sequence or sequences such as a sequence alignment, possibly with sequence features or properties shown.',
+    ]));
+    $operation_idspace->saveTerm(new TripalTerm([
+      'accession' => '0525',
+      'name' => 'genome assembly',
+      'idSpace' => 'operation',
+      'vocabulary' => 'EDAM',
+      'definition' => '',
+    ]));
+    $operation_idspace->saveTerm(new TripalTerm([
+      'accession' => '0362',
+      'name' => 'Genome annotation ',
+      'idSpace' => 'operation',
+      'vocabulary' => 'EDAM',
+      'definition' => '',
+    ]));
+    $operation_idspace->saveTerm(new TripalTerm([
+      'accession' => '2945',
+      'name' => 'Analysis',
+      'idSpace' => 'operation',
+      'vocabulary' => 'EDAM',
+      'definition' => 'Apply analytical methods to existing data of a specific type.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'analysis_id', $term);
+
+  }
+
+  /**
+   * Adds the Experimental Factor Ontology and terms.
+   */
+  private function addOntologyEFO() {
+    $vocab = $this->getVocabulary('efo');
+    $vocab->setLabel('The Experimental Factor Ontology (EFO) provides a systematic description of many experimental variables available in EBI databases, and for external projects such as the NHGRI GWAS catalogue. It combines parts of several biological ontologies, such as anatomy, disease and chemical compounds. The scope of EFO is to support the annotation, analysis and visualization of data handled by many groups at the EBI and as the core ontology for OpenTargets.org');
+    $idspace = $this->getIdSpace('EFO');
+    $idspace->setDescription('Experimental Factor Ontology');
+    $idspace->setUrlPrefix('http://www.ebi.ac.uk/efo/{db}_{accession}');
+    $idspace->setDefaultVocabulary('efo');
+    $vocab->addIdSpace('EFO');
+    $vocab->setUrl('http://www.ebi.ac.uk/efo/efo.owl');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000548',
+      'name' => 'instrument',
+      'idSpace' => 'EFO',
+      'vocabulary' => 'efo',
+      'definition' => 'An instrument is a device which provides a mechanical or electronic function.',
+    ]));
+    //chado_associate_semweb_term('protocol', 'hardwaredescription', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000269',
+      'name' => 'array design',
+      'idSpace' => 'EFO',
+      'vocabulary' => 'efo',
+      'definition' => 'An instrument design which describes the design of the array.',
+    ]));
+    //chado_associate_semweb_term('assay', 'arraydesign_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0005522',
+      'name' => 'substrate type',
+      'idSpace' => 'EFO',
+      'vocabulary' => 'efo',
+      'definition' => 'Controlled terms for descriptors of types of array substrates.',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'substratetype_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0001728',
+      'name' => 'array manufacturer',
+      'idSpace' => 'EFO',
+      'vocabulary' => 'efo',
+      'definition' => '',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'manufacturer_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000269',
+      'name' => 'array design',
+      'idSpace' => 'EFO',
+      'vocabulary' => 'efo',
+      'definition' => 'An instrument design which describes the design of the array.',
+    ]));
+    //chado_associate_semweb_term('element', 'arraydesign_id', $term);
+  }
+
+  /**
+   * Adds the Eagle-i Resource Ontology database and terms.
+   */
+  private function addOntologyERO() {
+    $vocab = $this->getVocabulary('ero');
+    $vocab->setLabel('The Eagle-I Research Resource Ontology models research resources such instruments. protocols, reagents, animal models and biospecimens. It has been developed in the context of the eagle-i project (http://eagle-i.net/).');
+    $idspace = $this->getIdSpace('ERO');
+    $idspace->setDescription('The Eagle-I Research Resource Ontology');
+    $idspace->setUrlPrefix('http://purl.bioontology.org/ontology/ERO/{db}:{accession}');
+    $idspace->setDefaultVocabulary('ero');
+    $vocab->addIdSpace('ERO');
+    $vocab->setUrl('http://purl.bioontology.org/ontology/ERO');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0001716',
+      'name' => 'database',
+      'idSpace' => 'ERO',
+      'vocabulary' => 'ero',
+      'definition' => 'A database is an organized collection of data, today typically in digital form.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'db_id', $term);
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000387',
+      'name' => 'data acquisition',
+      'idSpace' => 'ERO',
+      'vocabulary' => 'ero',
+      'definition' => 'A technique that samples real world physical conditions and conversion of the resulting samples into digital numeric values that can be manipulated by a computer.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'acquisition_id', $term);
+  }
+
+  /**
+   * Adds the Information Artifact Ontology database and terms.
+   */
+  private function addOntologyOBCS() {
+    $vocab = $this->getVocabulary('OBCS');
+    $vocab->setLabel('Ontology of Biological and Clinical Statistics');
+    $idspace = $this->getIdSpace('OBCS');
+    $idspace->setDescription("Ontology of Biological and Clinical Statistics");
+    $idspace->setURLPrefix("http://purl.obolibrary.org/obo/{db}_{accession}");
+    $idspace->setDefaultVocabulary('OBCS');
+    $vocab->addIdSpace('OBCS');
+    $vocab->setURL('https://github.com/obcs/obcs');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000117',
+      'name' => 'rank order',
+      'idSpace' => 'OBCS',
+      'vocabulary' => 'OBCS',
+      'definition' => 'A data item that represents an arrangement according to a rank, i.e., the position of a particular case relative to other cases on a defined scale.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'rank', $term);
+  }
+
+  /**
+   * Adds the Information Artifact Ontology database and terms.
+   */
+  private function addOntologyOBI() {
+    $vocab = $this->getVocabulary('obi');
+    $vocab->setLabel('Ontology for Biomedical Investigation. The Ontology for Biomedical Investigations (OBI) is build in a collaborative, international effort and will serve as a resource for annotating biomedical investigations, including the study design, protocols and instrumentation used, the data generated and the types of analysis performed on the data. This ontology arose from the Functional Genomics Investigation Ontology (FuGO) and will contain both terms that are common to all biomedical investigations, including functional genomics investigations and those that are more domain specific');
+    $idspace = $this->getIdSpace('OBI');
+    $idspace->setDescription("The Ontology for Biomedical Investigation");
+    $idspace->setURLPrefix("http://purl.obolibrary.org/obo/{db}_{accession}");
+    $idspace->setDefaultVocabulary('obi');
+    $vocab->addIdSpace('OBI');
+    $vocab->setURL('http://obi-ontology.org/page/Main_Page');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0100026',
+      'name' => 'organism',
+      'idSpace' => 'OBI',
+      'vocabulary' => 'obi',
+      'definition' => 'A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'organism_id', $term);
+    //chado_associate_semweb_term('biomaterial', 'taxon_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000070',
+      'name' => 'assay',
+      'idSpace' => 'OBI',
+      'vocabulary' => 'obi',
+      'definition' => 'A planned process with the objective to produce information about the material entity that is the evaluant, by physically examining it or its proxies.',
+    ]));
+  }
+
+  /**
+   * Adds the Ontology for genetic interval database and terms.
+   */
+  private function addOntologyOGI() {
+    $vocab = $this->getVocabulary('ogi');
+    $vocab->setLabel('Ontology for Biomedical Investigation. The Ontology for Biomedical Investigations (OBI) is build in a collaborative, international effort and will serve as a resource for annotating biomedical investigations, including the study design, protocols and instrumentation used, the data generated and the types of analysis performed on the data. This ontology arose from the Functional Genomics Investigation Ontology (FuGO) and will contain both terms that are common to all biomedical investigations, including functional genomics investigations and those that are more domain specific');
+    $idspace = $this->getIdSpace('OGI');
+    $idspace->setDescription("Ontology for genetic interval");
+    $idspace->setURLPrefix("http://purl.obolibrary.org/obo/{db}_{accession}");
+    $idspace->setDefaultVocabulary('ogi');
+    $vocab->addIdSpace('OGI');
+    $vocab->setURL('http://purl.bioontology.org/ontology/OGI');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000021',
+      'name' => 'location on map',
+      'idSpace' => 'OGI',
+      'vocabulary' => 'ogi',
+      'definition' => '',
+    ]));
+  }
+
+  /**
+   * Adds the Information Artifact Ontology database and terms.
+   */
+  private function addOntologyIAO() {
+
+    $vocab = $this->getVocabulary('IAO');
+    $vocab->setLabel('Information Artifact Ontology');
+    $idspace = $this->getIdSpace('IAO');
+    $idspace->setDescription('Information Artifact Ontology');
+    $idspace->setUrlPrefix('http://purl.obolibrary.org/obo/{db}_{accession}');
+    $idspace->setDefaultVocabulary('IAO');
+    $vocab->addIdSpace('IAO');
+    $vocab->setUrl('https://github.com/information-artifact-ontology/IAO/');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000115',
+      'name' => 'definition',
+      'vocabulary' => 'IAO',
+      'idSpace' => 'IAO',
+      'definition' => 'The official OBI definition, explaining the meaning of ' .
+        'a class or property. Shall be Aristotelian, formalized and normalized. ' .
+        'Can be augmented with colloquial definitions.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'definition', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000129',
+      'name' => 'version number',
+      'vocabulary' => 'IAO',
+      'idSpace' => 'IAO',
+      'definition' => 'A version number is an ' .
+        'information content entity which is a sequence of characters ' .
+        'borne by part of each of a class of manufactured products or its ' .
+        'packaging and indicates its order within a set of other products ' .
+        'having the same name.',
+    ]));
+    //chado_associate_semweb_term('analysis', 'programversion', $term);
+    //chado_associate_semweb_term('analysis', 'sourceversion', $term);
+    //chado_associate_semweb_term(NULL, 'version', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000064',
+      'name' => 'algorithm',
+      'idSpace' => 'IAO',
+      'vocabulary' => 'IAO',
+      'definition' => 'An algorithm is a set of instructions for performing a paticular calculation.',
+    ]));
+    //chado_associate_semweb_term('analysis', 'algorithm', $term);
+  }
+
+  private function addOntologyNull() {
+    $vocab = $this->getVocabulary('null');
+    $vocab->setLabel('No vocabulary');
+    $idspace = $this->getIdSpace('null');
+    $idspace->setDescription('No database');
+    $idspace->setUrlPrefix('cv/lookup/{db}/{accession}');
+    $idspace->setDefaultVocabulary('null');
+    $vocab->addIdSpace('null');
+    $vocab->setUrl('cv/lookup/null');
+  }
+
+  /**
+   * Adds terms to the 'local' database.
+   */
+  private function addOntologyLocal() {
+
+    $vocab = $this->getVocabulary('local');
+    $vocab->setLabel('Locally created terms');
+    $idspace = $this->getIdSpace('local');
+    $idspace->setDescription('Terms created for this site');
+    $idspace->setUrlPrefix('cv/lookup/{db}/{accession}');
+    $idspace->setDefaultVocabulary('local');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('organism_property');
+    $vocab->setLabel('A local vocabulary that contains locally defined properties for organisms');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('analysis_property');
+    $vocab->setLabel('A local vocabulary that contains locally defined properties for analyses');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('tripal_phylogeny');
+    $vocab->setLabel('Terms used by the Tripal phylotree module for phylogenetic and taxonomic trees');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('feature_relationship');
+    $vocab->setLabel('A local vocabulary that contains types of relationships between features');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('feature_property');
+    $vocab->setLabel('A local vocabulary that contains properties for genomic features');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('contact_property');
+    $vocab->setLabel('A local vocabulary that contains properties for contacts. This can be used if the tripal_contact vocabulary (which is default for contacts in Tripal) is not desired.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('contact_type');
+    $vocab->setLabel('A local vocabulary that contains types of contacts. This can be used if the tripal_contact vocabulary (which is default for contacts in Tripal) is not desired.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('tripal_contact');
+    $vocab->setLabel('A local vocabulary that contains a heirarchical set of terms for describing a contact. It is intended to be used as the default vocabularies in Tripal for contact types and contact properties.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('contact_relationship');
+    $vocab->setLabel('A local vocabulary that contains types of relationships between contacts.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('featuremap_units');
+    $vocab->setLabel('A local vocabulary that contains map unit types for the unittype_id column of the featuremap table.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('featurepos_property');
+    $vocab->setLabel('A local vocabulary that contains terms map properties.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('featuremap_property');
+    $vocab->setLabel('A local vocabulary that contains positional types for the feature positions.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('library_property');
+    $vocab->setLabel('A local vocabulary that contains properties for libraries.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('library_type');
+    $vocab->setLabel('A local vocabulary that contains terms for types of libraries (e.g. BAC, cDNA, FOSMID, etc).');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('project_property');
+    $vocab->setLabel('A local vocabulary that contains properties for projects.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('study_property');
+    $vocab->setLabel('A local vocabulary that contains properties for studies.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('project_relationship');
+    $vocab->setLabel('A local vocabulary that contains Types of relationships between projects');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('tripal_pub');
+    $vocab->setLabel('A local vocabulary that contains a heirarchical set of terms for describing a publication. It is intended to be used as the default vocabularies in Tripal for publication types and contact properties.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('pub_type');
+    $vocab->setLabel('A local vocabulary that contains types of publications. This can be used if the tripal_pub vocabulary (which is default for publications in Tripal) is not desired.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('pub_property');
+    $vocab->setLabel('A local vocabulary that contains properties for publications. This can be used if the tripal_pub vocabulary (which is default for publications in Tripal) is not desired.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('pub_relationship');
+    $vocab->setLabel('A local vocabulary that contains types of relationships between publications.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('stock_relationship');
+    $vocab->setLabel('A local vocabulary that contains types of relationships between stocks.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('stock_property');
+    $vocab->setLabel('A local vocabulary that contains properties for stocks.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('stock_type');
+    $vocab->setLabel('A local vocabulary that contains a list of types for stocks.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('tripal_analysis');
+    $vocab->setLabel('A local vocabulary that contains terms used for analyses.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('nd_experiment_types');
+    $vocab->setLabel('A local vocabulary that contains terms used for the Natural Diverisity module\'s experiment types.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+    $vocab = $this->getVocabulary('nd_geolocation_property');
+    $vocab->setLabel('A local vocabulary that contains terms used for the Natural Diverisity module\'s geolocation property.');
+    $vocab->addIdSpace('local');
+    $vocab->setUrl('cv/lookup/local');
+
+
+
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'property',
+      'name' => 'property',
+      'idSpace' => 'local',
+      'vocabulary' => 'local',
+      'definition' => 'A generic term indicating that represents an attribute, quality or characteristic of something.',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'timelastmodified',
+      'name' => 'time_last_modified',
+      'idSpace' => 'local',
+      'vocabulary' => 'local',
+      'definition' => 'The time at which the record was last modified.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'timelastmodified', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'timeaccessioned',
+      'name' => 'time_accessioned',
+      'idSpace' => 'local',
+      'vocabulary' => 'local',
+      'definition' => 'The time at which the record was first added.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'timeaccessioned', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'timeexecuted',
+      'name' => 'time_executed',
+      'idSpace' => 'local',
+      'vocabulary' => 'local',
+      'definition' => 'The time when the task was executed.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'timeexecuted', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'infraspecific_type',
+      'name' => 'infraspecific_type',
+      'idSpace' => 'local',
+      'definition' => 'The connector type (e.g. subspecies, varietas, forma, etc.) for the infraspecific name',
+      'vocabulary' => 'local',
+    ]));
+    //chado_associate_semweb_term('organism', 'type_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'abbreviation',
+      'name' => 'abbreviation',
+      'idSpace' => 'local',
+      'vocabulary' => 'local',
+      'definition' => 'A shortened name (or abbreviation) for the item.',
+    ]));
+    //chado_associate_semweb_term('organism', 'abbreviation', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'expression',
+      'name' => 'expression',
+      'idSpace' => 'local',
+      'definition' => 'Curated expression data',
+      'vocabulary' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'is_analysis',
+      'name' => 'is_analysis',
+      'idSpace' => 'local',
+      'definition' => 'Indicates if this feature was predicted computationally using another feature.',
+      'vocabulary' => 'local',
+    ]));
+    //chado_associate_semweb_term('feature', 'is_analysis', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'is_obsolete',
+      'name' => 'is_obsolete',
+      'idSpace' => 'local',
+      'definition' => 'Indicates if this record is obsolete.',
+      'vocabulary' => 'local',
+    ]));
+    //chado_associate_semweb_term(NULL, 'is_obsolete', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'is_current',
+      'name' => 'is_current',
+      'idSpace' => 'local',
+      'definition' => 'Indicates if this record is current.',
+      'vocabulary' => 'local',
+    ]));
+    //chado_associate_semweb_term(NULL, 'is_current', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'is_internal',
+      'name' => 'is_internal',
+      'idSpace' => 'local',
+      'definition' => 'Indicates if this record is internal and not normally available outside of a local setting.',
+      'vocabulary' => 'local',
+    ]));
+    //chado_associate_semweb_term(NULL, 'is_internal', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'miniref',
+      'name' => 'Mini-ref',
+      'idSpace' => 'local',
+      'definition' => 'A small in-house unique identifier for a publication.',
+      'vocabulary' => 'local',
+    ]));
+    //chado_associate_semweb_term('pub', 'miniref', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'array_batch_identifier',
+      'name' => 'Array Batch Identifier',
+      'idSpace' => 'local',
+      'definition' => 'A unique identifier for an array batch.',
+      'vocabulary' => 'local',
+    ]));
+    //chado_associate_semweb_term('assay', 'arraybatchidentifier', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'relationship_subject',
+      'name' => 'clause subject',
+      'idSpace' => 'local',
+      'definition' => 'The subject of a relationship clause.',
+      'vocabulary' => 'local',
+    ]));
+    //chado_associate_semweb_term(NULL, 'subject_id', $term);
+    //chado_associate_semweb_term(NULL, 'subject_reagent_id', $term);
+    //chado_associate_semweb_term(NULL, 'subject_project_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'relationship_object',
+      'name' => 'clause predicate',
+      'idSpace' => 'local',
+      'definition' => 'The object of a relationship clause.',
+      'vocabulary' => 'local',
+    ]));
+    //chado_associate_semweb_term(NULL, 'object_id', $term);
+    //chado_associate_semweb_term(NULL, 'object_reagent_id', $term);
+    //chado_associate_semweb_term(NULL, 'object_project_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'relationship_type',
+      'name' => 'relationship type',
+      'idSpace' => 'local',
+      'definition' => 'The relationship type.',
+      'vocabulary' => 'local',
+    ]));
+    //chado_associate_semweb_term('acquisition_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('biomaterial_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('cell_line_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('contact_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('element_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('elementresult_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('feature_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('nd_reagent_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('phylonode_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('project_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('pub_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('quantification_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('stock_relationship', 'type_id', $term);
+    //chado_associate_semweb_term('cvterm_relationship', 'type_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'rank',
+      'name' => 'rank',
+      'idSpace' => 'local',
+      'definition' => 'A taxonmic rank',
+      'vocabulary' => 'organism_property',
+    ]));
+
+    $terms = [
+      'lineage',
+      'genetic_code',
+      'genetic_code_name',
+      'mitochondrial_genetic_code',
+      'mitochondrial_genetic_code_name',
+      'division',
+      'genbank_common_name',
+      'synonym',
+      'other_name',
+      'equivalent_name',
+      'anamorph',
+    ];
+    foreach ($terms as $term) {
+      $idspace->saveTerm(new TripalTerm([
+        'name' => $term,
+        'accession' => $term,
+        'definition' => '',
+        'idSpace' => 'local',
+        'vocabulary' => 'organism_property',
+      ]));
+    }
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'phylo_leaf',
+      'accession' => 'phylo_leaf',
+      'definition' => 'A leaf node in a phylogenetic tree.',
+      'vocabulary' => 'tripal_phylogeny',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'phylo_root',
+      'accession' => 'phylo_root',
+      'definition' => 'The root node of a phylogenetic tree.',
+      'vocabulary' => 'tripal_phylogeny',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'phylo_interior',
+      'accession' => 'phylo_interior',
+      'definition' => 'An interior node in a phylogenetic tree.',
+      'vocabulary' => 'tripal_phylogeny',
+      'idSpace' => 'local',
+    ]));
+
+    // Add the terms used to identify nodes in the tree.
+    // DEPRECATED: use EDAM's data 'Species tree' term instead.
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'taxonomy',
+      'accession' => 'taxonomy',
+      'definition' => 'A term used to indicate if a phylotree is a taxonomic tree',
+      'vocabulary' => 'tripal_phylogeny',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Project Description',
+      'accession' => 'Project Description',
+      'definition' => 'Description of a project',
+      'vocabulary' => 'project_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Project Type',
+      'accession' => 'Project Type',
+      'definition' => 'A type of project',
+      'vocabulary' => 'project_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Genotyping',
+      'accession' => 'Genotyping',
+      'definition' => 'An experiment where genotypes of individuals are identified.',
+      'vocabulary' => 'nd_experiment_types',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Phenotyping',
+      'accession' => 'Phenotyping',
+      'definition' => 'An experiment where phenotypes of individuals are identified.',
+      'vocabulary' => 'nd_experiment_types',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Location',
+      'accession' => 'Location',
+      'definition' => 'The name of the location.',
+      'vocabulary' => 'nd_geolocation_property',
+      'idSpace' => 'local',
+    ]));
+
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'library',
+      'name' => 'Library',
+      'definition' => 'A group of physical entities organized into a collection',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term(NULL, 'library_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'library_description',
+      'name' => 'Library Description',
+      'definition' => 'Description of a library',
+      'vocabulary' => 'library_property',
+      'idSpace' => 'local',
+    ]));
+
+    // add cvterms for the map unit types
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'cdna_library',
+      'name' => 'cdna_library',
+      'definition' => 'cDNA library',
+      'vocabulary' => 'library_type',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'bac_library',
+      'name' => 'bac_library',
+      'definition' => 'Bacterial Artifical Chromsome (BAC) library',
+      'vocabulary' => 'library_type',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'fosmid_library',
+      'name' => 'fosmid_library',
+      'definition' => 'Fosmid library',
+      'vocabulary' => 'library_type',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'cosmid_library',
+      'name' => 'cosmid_library',
+      'definition' => 'Cosmid library',
+      'vocabulary' => 'library_type',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'yac_library',
+      'name' => 'yac_library',
+      'definition' => 'Yeast Artificial Chromosome (YAC) library',
+      'vocabulary' => 'library_type',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'genomic_library',
+      'name' => 'genomic_library',
+      'definition' => 'Genomic Library',
+      'vocabulary' => 'library_type',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'fasta_definition',
+      'accession' => 'fasta_definition',
+      'definition' => 'The definition line for a FASTA formatted sequence',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'cM',
+      'accession' => 'cM',
+      'definition' => 'Centimorgan units',
+      'vocabulary' => 'featuremap_units',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'bp',
+      'accession' => 'bp',
+      'definition' => 'Base pairs units',
+      'vocabulary' => 'featuremap_units',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'bin_unit',
+      'accession' => 'bin_unit',
+      'definition' => 'The bin unit',
+      'vocabulary' => 'featuremap_units',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'marker_order',
+      'accession' => 'marker_order',
+      'definition' => 'Units simply to define marker order.',
+      'vocabulary' => 'featuremap_units',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'undefined',
+      'accession' => 'undefined',
+      'definition' => 'A catch-all for an undefined unit type',
+      'vocabulary' => 'featuremap_units',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'start',
+      'accession' => 'start',
+      'definition' => 'The start coordinate for a map feature.',
+      'vocabulary' => 'featurepos_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'stop',
+      'accession' => 'stop',
+      'definition' => 'The end coordinate for a map feature',
+      'vocabulary' => 'featurepos_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Map Dbxref',
+      'accession' => 'Map Dbxref',
+      'definition' => 'A unique identifer for the map in a remote database.  The ' .
+        'format is a database abbreviation and a unique accession separated ' .
+        'by a colon.  (e.g. Gramene:tsh1996a)',
+      'vocabulary' => 'featuremap_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Map Type',
+      'accession' => 'Map Type',
+      'definition' => 'The type of Map (e.g. QTL, Physical, etc.)',
+      'vocabulary' => 'featuremap_property',
+      'is_relationship' => 0,
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Genome Group',
+      'accession' => 'Genome Group',
+      'definition' => '',
+      'vocabulary' => 'featuremap_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'URL',
+      'accession' => 'URL',
+      'definition' => 'A univeral resource locator (URL) reference where the ' .
+        'publication can be found.  For maps found online, this would be ' .
+        'the web address for the map.',
+      'vocabulary' => 'featuremap_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Population Type',
+      'accession' => 'Population Type',
+      'definition' => 'A brief description of the population type used to generate ' .
+        'the map (e.g. RIL, F2, BC1, etc).',
+      'vocabulary' => 'featuremap_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Population Size',
+      'accession' => 'Population Size',
+      'definition' => 'The size of the population used to construct the map.',
+      'vocabulary' => 'featuremap_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Methods',
+      'accession' => 'Methods',
+      'definition' => 'A brief description of the methods used to construct the map.',
+      'vocabulary' => 'featuremap_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Software',
+      'accession' => 'Software',
+      'definition' => 'The software used to construct the map.',
+      'vocabulary' => 'featuremap_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Reference Feature',
+      'accession' => 'Reference Feature',
+      'definition' => 'A genomic or genetic feature on which other features are mapped.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('featurepos', 'map_feature_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'fmin',
+      'name' => 'minimal boundary',
+      'definition' => 'The leftmost, minimal boundary in the linear range ' .
+        'represented by the feature location. Sometimes this is called ' .
+        'start although this is confusing because it does not necessarily ' .
+        'represent the 5-prime coordinate.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('featureloc', 'fmin', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'fmax',
+      'name' => 'maximal boundary',
+      'definition' => 'The rightmost, maximal boundary in the linear range ' .
+        'represented by the featureloc. Sometimes this is called end although ' .
+        'this is confusing because it does not necessarily represent the ' .
+        '3-prime coordinate',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('featureloc', 'fmax', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'analysis_date',
+      'accession' => 'analysis_date',
+      'definition' => 'The date that an analysis was performed.',
+      'vocabulary' => 'tripal_analysis',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'analysis_short_name',
+      'accession' => 'analysis_short_name',
+      'definition' => 'A computer legible (no spaces or special characters) abbreviation for the analysis.',
+      'vocabulary' => 'tripal_analysis',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'Analysis Type',
+      'name' => 'Analysis Type',
+      'definition' => 'The type of analysis that was performed.',
+      'vocabulary' => 'analysis_property',
+      'idSpace' => 'local',
+    ]));
+
+    // Add a term to be used for an inherent 'type_id' for the organism table.
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'analysis',
+      'name' => 'analysis',
+      'definition' => 'A process as a method of studying the nature of something ' .
+        'or of determining its essential features and their relations. ' .
+        '(Random House Kernerman Webster\'s College Dictionary, © 2010 K ' .
+        'Dictionaries Ltd).',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'source_data',
+      'name' => 'source_data',
+      'definition' => 'The location where data that is being used come from.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'contact',
+      'name' => 'contact',
+      'definition' => 'An entity (e.g. individual or organization) through ' .
+        'whom a person can gain access to information, favors, ' .
+        'influential people, and the like.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('biomaterial', 'biosourceprovider_id', $term);
+    //chado_associate_semweb_term(NULL, 'contact_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'relationship',
+      'name' => 'relationship',
+      'definition' => 'The way in which two things are connected.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'biomaterial',
+      'name' => 'biomaterial',
+      'definition' => 'A biomaterial represents the MAGE concept of BioSource, BioSample, ' .
+        'and LabeledExtract. It is essentially some biological material (tissue, cells, serum) that ' .
+        'may have been processed. Processed biomaterials should be traceable back to raw ' .
+        'biomaterials via the biomaterialrelationship table.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'array_dimensions',
+      'name' => 'array_dimensions',
+      'definition' => 'The dimensions of an array.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'array_dimensions', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'element_dimensions',
+      'name' => 'element_dimensions',
+      'definition' => 'The dimensions of an element.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'element_dimensions', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'num_of_elements',
+      'name' => 'num_of_elements',
+      'definition' => 'The number of elements.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'num_of_elements', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'num_array_columns',
+      'name' => 'num_array_columns',
+      'definition' => 'The number of columns in an array.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'num_array_columns', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'num_array_rows',
+      'name' => 'num_array_rows',
+      'definition' => 'The number of rows in an array.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'num_array_rows', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'num_grid_columns',
+      'name' => 'num_grid_columns',
+      'definition' => 'The number of columns in a grid.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'num_grid_columns', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'num_grid_rows',
+      'name' => 'num_grid_rows',
+      'definition' => 'The number of rows in a grid.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'num_grid_rows', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'num_sub_columns',
+      'name' => 'num_sub_columns',
+      'definition' => 'The number of sub columns.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'num_sub_columns', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'num_sub_rows',
+      'name' => 'num_sub_rows',
+      'definition' => 'The number of sub rows.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'num_sub_rows', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'name' => 'Study Type',
+      'accession' => 'Study Type',
+      'definition' => 'A type of study',
+      'vocabulary' => 'study_property',
+      'idSpace' => 'local',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'Genome Project',
+      'name' => 'Genome Project',
+      'definition' => 'A project for whole genome analysis that can include assembly and annotation.',
+      'vocabulary' => 'local',
+      'idSpace' => 'local',
+    ]));
+
+  }
+
+  /**
+   * Adds the Systems Biology Ontology database and terms.
+   */
+  private function addOntologySBO() {
+
+    $vocab = $this->getVocabulary('sbo');
+    $vocab->setLabel('Systems Biology.  Terms commonly used in Systems Biology, and in particular in computational modeling.');
+    $idspace = $this->getIdSpace('SBO');
+    $idspace->setDescription("Systems Biology Ontology");
+    $idspace->setURLPrefix("http://purl.obolibrary.org/obo/{db}_{accession}");
+    $idspace->setDefaultVocabulary('sbo');
+    $vocab->addIdSpace('SBO');
+    $vocab->setURL('http://www.ebi.ac.uk/sbo/main/');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000358',
+      'name' => 'phenotype',
+      'idSpace' => 'SBO',
+      'vocabulary' => 'sbo',
+      'definition' => 'A biochemical network can generate phenotypes or affects biological processes. Such processes can take place at different levels and are independent of the biochemical network itself.',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000554',
+      'name' => 'database cross reference',
+      'idSpace' => 'SBO',
+      'vocabulary' => 'sbo',
+      'definition' => 'An annotation which directs one to information contained within a database.',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000374',
+      'name' => 'relationship',
+      'idSpace' => 'SBO',
+      'vocabulary' => 'sbo',
+      'definition' => 'Connectedness between entities and/or interactions representing their relatedness or influence.',
+    ]));
+  }
+
+  /**
+   * Adds the "Bioinformatics operations, data types, formats, identifiers and
+   * topics" database and terms.
+   */
+  private function addOntologySWO() {
+
+    $vocab = $this->getVocabulary('swo');
+    $vocab->setLabel('Bioinformatics operations, data types, formats, identifiers and topics');
+    $idspace = $this->getIdSpace('SWO');
+    $idspace->setDescription("Bioinformatics operations, data types, formats, identifiers and topics");
+    $idspace->setURLPrefix("http://www.ebi.ac.uk/swo/{db}_{accession}");
+    $idspace->setDefaultVocabulary('swo');
+    $vocab->addIdSpace('SWO');
+    $vocab->setURL('http://purl.obolibrary.org/obo/swo');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000001',
+      'name' => 'software',
+      'idSpace' => 'SWO',
+      'vocabulary' => 'swo',
+      'definition' => 'Computer software, or generally just software, is any ' .
+        'set of machine-readable instructions (most often in the form of a ' .
+        'computer program) that conform to a given syntax (sometimes ' .
+        'referred to as a language) that is interpretable by a given ' .
+        'processor and that directs a computer\'s processor to perform ' .
+        'specific operations.',
+    ]));
+    //chado_associate_semweb_term('analysis', 'program', $term);
+    //chado_associate_semweb_term('protocol', 'softwaredescription', $term);
+  }
+
+
+
+  /**
+   * Adds the PUbMed Ontology and terms.
+   */
+  private function addOntologyPMID() {
+    $vocab = $this->getVocabulary('PMID');
+    $vocab->setLabel('PubMed.');
+    $idspace = $this->getIdSpace('PMID');
+    $idspace->setDescription("PubMed");
+    $idspace->setURLPrefix("http://www.ncbi.nlm.nih.gov/pubmed/{accession}");
+    $idspace->setDefaultVocabulary('PMID');
+    $vocab->addIdSpace('PMID');
+    $vocab->setURL('http://www.ncbi.nlm.nih.gov/pubmed');
+  }
+
+
+  /**
+   * Adds the Uni Ontology database, terms and mappings.
+   */
+  private function addOntologyUO() {
+    $vocab = $this->getVocabulary('uo');
+    $vocab->setLabel('Units of Measurement Ontology');
+    $idspace = $this->getIdSpace('UO');
+    $idspace->setDescription("Units of Measurement Ontology");
+    $idspace->setURLPrefix("http://purl.obolibrary.org/obo/UO_{accession}");
+    $idspace->setDefaultVocabulary('uo');
+    $vocab->addIdSpace('UO');
+    $vocab->setURL('http://purl.obolibrary.org/obo/uo');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => '0000000',
+      'name' => 'unit',
+      'idSpace' => 'UO',
+      'vocabulary' => 'uo',
+      'description' => 'A unit of measurement is a standardized quantity of a physical quality.',
+    ]));
+    //chado_associate_semweb_term('featuremap', 'unittype_id', $term);
+  }
+
+
+  /**
+   * Adds the NCIT vocabulary database and terms.
+   */
+  private function addOntologyNCIT() {
+    $vocab = $this->getVocabulary('ncit');
+    $vocab->setLabel('NCI Thesaurus OBO Edition');
+    $idspace = $this->getIdSpace('NCIT');
+    $idspace->setDescription('The NCIt is a reference terminology that includes broad coverage of the cancer domain, including cancer related diseases, findings and abnormalities. NCIt OBO Edition releases should be considered experimental.');
+    $idspace->setUrlPrefix('http://purl.obolibrary.org/obo/{db}_{accession}');
+    $idspace->setDefaultVocabulary('ncit');
+    $vocab->addIdSpace('NCIT');
+    $vocab->setUrl('http://purl.obolibrary.org/obo/ncit.owl');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C25164',
+      'name' => 'Date',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'The particular day, month and year an event has happened or will happen.',
+    ]));
+    //chado_associate_semweb_term('assay', 'assaydate', $term);
+    //chado_associate_semweb_term('acquisition', 'acquisitiondate', $term);
+    //chado_associate_semweb_term('quantification', 'quantificationdate', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C48036',
+      'name' => 'Operator',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'A person that operates some apparatus or machine',
+    ]));
+    //chado_associate_semweb_term(NULL, 'operator_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C45378',
+      'name' => 'Technology Platform',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'The specific version (manufacturer, model, etc.) of a technology that is used to carry out a laboratory or computational experiment.',
+    ]));
+    //chado_associate_semweb_term('arraydesign', 'platformtype_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C25712',
+      'name' => 'Value',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'A numerical quantity measured or assigned or computed.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'value', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C44170',
+      'name' => 'Channel',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'An independent acquisition scheme, i.e., a route or conduit through which flows data consisting of one particular measurement using one particular parameter.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'channel_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C48697',
+      'name' => 'Controlled Vocabulary',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'A set of terms that are selected and defined based on the requirements set out by the user group, usually a set of vocabulary is chosen to promote consistency across data collection projects. [ NCI ]',
+    ]));
+    //chado_associate_semweb_term(NULL, 'cv_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C45559',
+      'name' => 'Term',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'A word or expression used for some particular thing. [ NCI ]',
+    ]));
+    //chado_associate_semweb_term(NULL, 'cvterm_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C80488',
+      'name' => 'Expression',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'A combination of symbols that represents a value. [ NCI ]',
+    ]));
+    //chado_associate_semweb_term(NULL, 'expression_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C16977',
+      'name' => 'Phenotype',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'The assemblage of traits or outward appearance of an individual. It is the product of interactions between genes and between genes and the environment. [ NCI ]',
+    ]));
+    //chado_associate_semweb_term(NULL, 'phenotype_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C16631',
+      'name' => 'Genotype',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'The genetic constitution of an organism or cell, as distinct from its expressed features or phenotype. [ NCI ]',
+    ]));
+    //chado_associate_semweb_term(NULL, 'genotype_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C25341',
+      'name' => 'Location',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'A position, site, or point in space where something can be found. [ NCI ]',
+    ]));
+    //chado_associate_semweb_term(NULL, 'nd_geolocation_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C802',
+      'name' => 'Reagent',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'Any natural or synthetic substance used in a chemical or biological reaction in order to produce, identify, or measure another substance. [ NCI ]',
+    ]));
+    //chado_associate_semweb_term(NULL, 'nd_reagent_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C16551',
+      'name' => 'Environment',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'The totality of surrounding conditions. [ NCI ]',
+    ]));
+    //chado_associate_semweb_term(NULL, 'environment_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C42765',
+      'name' => 'Tree Node',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'A term that refers to any individual item or entity in a hierarchy or pedigree. [ NCI ]',
+    ]));
+    //chado_associate_semweb_term(NULL, 'phylonode_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C15320',
+      'name' => 'Study Design',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'A plan detailing how a study will be performed in order to represent the phenomenon under examination, to answer the research questions that have been asked, and defining the methods of data analysis. Study design is driven by research hypothesis being posed, study subject/population/sample available, logistics/resources: technology, support, networking, collaborative support, etc. [ NCI ]',
+    ]));
+    //chado_associate_semweb_term(NULL, 'studydesign_id', $term);
+
+    // The Company term is missing for the Tripal Contact ontology, but is
+    // useful for the arraydesign.manufacturer which is an FK to Contact.
+    // It seems better to use a term from a curated ontology than to add to
+    // Tripal Contact.
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C54131',
+      'name' => 'Company',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'Any formal business entity for profit, which may be a corporation, a partnership, association or individual proprietorship.',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C47885',
+      'name' => 'Project',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'Any specifically defined piece of work that is undertaken or attempted to meet a single requirement.',
+    ]));
+    //chado_associate_semweb_term(NULL, 'project_id', $term);
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C16223',
+      'name' => 'DNA Library',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'A collection of DNA molecules that have been cloned in vectors.',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C85496',
+      'name' => 'Trait',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'Any genetically determined characteristic.',
+    ]));
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'C25693',
+      'name' => 'Subgroup',
+      'idSpace' => 'NCIT',
+      'vocabulary' => 'ncit',
+      'definition' => 'A subdivision of a larger group with members often exhibiting similar characteristics. [ NCI ]',
+    ]));
+
+  }
+
+  /**
+   * Adds the NCBI Taxon vocabulary database and terms.
+   */
+  private function addOntologyNCBITaxon() {
+    $vocab = $this->getVocabulary('ncbitaxon');
+    $vocab->setLabel('NCBI organismal classification. An ontology representation of the NCBI organismal taxonomy');
+    $idspace = $this->getIdSpace('NCBITaxon');
+    $idspace->setDescription('NCBI organismal classification');
+    $idspace->setUrlPrefix('https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id={accession}');
+    $idspace->setDefaultVocabulary('ncbitaxon');
+    $vocab->addIdSpace('NCBITaxon');
+    $vocab->setUrl('http://www.berkeleybop.org/ontologies/ncbitaxon/');
+
+    $idspace->saveTerm(new TripalTerm([
+      'accession' => 'common_name',
+      'name' => 'common name',
+      'idSpace' => 'NCBITaxon',
+      'vocabulary' => 'ncbitaxon',
+      'description' => '',
+    ]));
+    //chado_associate_semweb_term('organism', 'common_name', $term);
+  }
+
+  /**
+   * Loads default vocabularies and term.
+   *
+   * These are only what is necessary for creation of default Tripal content
+   * types.
+   */
+  public function addOntologies() {
+
+    $this->addOntologyCO010();
+    $this->addOntologyDC();
+    $this->addOntologyEDAM();
+    $this->addOntologyEFO();
+    $this->addOntologyERO();
+    $this->addOntologyFOAF();
+    $this->addOntologyGO();
+    $this->addOntologyHydra();
+    $this->addOntologyIAO();
+    $this->addOntologyLocal();
+    $this->addOntologyNCBITaxon();
+    $this->addOntologyNCIT();
+    $this->addOntologyNull();
+    $this->addOntologyOBCS();
+    $this->addOntologyOBI();
+    $this->addOntologyOGI();
+    $this->addOntologyPMID();
+    $this->addOntologyRDF();
+    $this->addOntologyRDFS();
+    $this->addOntologyRO();
+    $this->addOntologySBO();
+    $this->addOntologySchema();
+    $this->addOntologySEP();
+    $this->addOntologySIO();
+    $this->addOntologySO();
+    $this->addOntologyTaxRank();
+    $this->addOntologyTContact();
+    $this->addOntologyTPub();
+    $this->addOntologyUO();
+  }
+
+  /**
+   * Imports ontologies into Chado.
+   */
+  protected function importOntologies() {
+    $ontologies = [];
     $ontologies[] = [
-      'vocabulary' => $cc_vocab,
-      'idSpace' => $GO_idspace,
+      'vocabulary' => $this->getVocabulary('ro'),
+      'idSpace' => $this->getIdSpace('RO'),
+      'path' => '{tripal_chado}/files/legacy_ro.obo',
+      'auto_load' => FALSE,
+    ];
+    $ontologies[] = [
+      'vocabulary' => $this->getVocabulary('cellular_component'),
+      'idSpace' => $this->getIdSpace('GO'),
       'path' => 'http://purl.obolibrary.org/obo/go.obo',
       'auto_load' => FALSE,
     ];
-
-    // SO
-    $sequence_vocab = $this->getVocabulary('sequence');
-    $sequence_vocab->setLabel('The Sequence Ontology');
-    $SO_idspace = $this->getIdSpace('SO');
-    $SO_idspace->setDescription("The Sequence Ontology");
-    $SO_idspace->setURLPrefix("http://www.sequenceontology.org/browser/current_svn/term/{db}:{accession}");
-    $SO_idspace->setDefaultVocabulary('sequence');
-    $sequence_vocab->addIdSpace('SO');
-    $sequence_vocab->setURL('http://www.sequenceontology.org');
     $ontologies[] = [
-      'vocabulary' => $sequence_vocab,
-      'idSpace' => $SO_idspace,
+      'vocabulary' => $this->getVocabulary('sequence'),
+      'idSpace' => $this->getIdSpace('SO'),
       'path' => 'http://purl.obolibrary.org/obo/so.obo',
       'auto_load' => TRUE,
     ];
-
-    // TAXRANK
-    $taxrank_vocab = $this->getVocabulary('taxonomic_rank');
-    $taxrank_vocab->setLabel('Taxonomic Rank');
-    $TAXRANK_idspace = $this->getIdSpace('TAXRANK');
-    $TAXRANK_idspace->setDescription("A vocabulary of taxonomic ranks (species, family, phylum, etc)");
-    $TAXRANK_idspace->setURLPrefix("http://purl.obolibrary.org/obo/{db}_{accession}");
-    $TAXRANK_idspace->setDefaultVocabulary('taxonomic_rank');
-    $taxrank_vocab->addIdSpace('TAXRANK');
-    $taxrank_vocab->setURL('http://www.obofoundry.org/ontology/taxrank.html');
-
     $ontologies[] = [
-      'vocabulary' => $taxrank_vocab,
-      'idSpace' => $TAXRANK_idspace,
+      'vocabulary' => $this->getVocabulary('taxonomic_rank'),
+      'idSpace' => $this->getIdSpace('TAXRANK'),
       'path' => 'http://purl.obolibrary.org/obo/taxrank.obo',
       'auto_load' => TRUE,
     ];
-
-    // TContact
-    $tcontact_vocab = $this->getVocabulary('tripal_contact');
-    $tcontact_vocab->setLabel('Tripal Contact Ontology');
-    $tcontact_idspace = $this->getIdSpace('TCONTACT');
-    $tcontact_idspace->setDescription("Tripal Contact Ontology. A temporary ontology until a more formal appropriate ontology an be identified.");
-    $tcontact_idspace->setURLPrefix("cv/lookup/TCONTACT/{accession}	");
-    $tcontact_idspace->setDefaultVocabulary('tripal_contact');
-    $tcontact_vocab->addIdSpace('TCONTACT');
-    $tcontact_vocab->setURL('cv/lookup/TCONTACT');
     $ontologies[] = [
-      'vocabulary' => $tcontact_vocab,
-      'idSpace' => $tcontact_idspace,
+      'vocabulary' => $this->getVocabulary('tripal_contact'),
+      'idSpace' => $this->getIdSpace('TCONTACT'),
       'path' => '{tripal_chado}/files/tcontact.obo',
       'auto_load' => TRUE,
     ];
-
-    // TPub
-    $tpub_vocab = $this->getVocabulary('tripal_pub');
-    $tpub_vocab->setLabel('Tripal Publication Ontology');
-    $tpub_idspace = $this->getIdSpace('TPUB');
-    $tpub_idspace->setDescription("Tripal Publication Ontology. A temporary ontology until a more formal appropriate ontology an be identified.");
-    $tpub_idspace->setURLPrefix("cv/lookup/TPUB/{accession}	");
-    $tpub_idspace->setDefaultVocabulary('tripal_pub');
-    $tpub_vocab->addIdSpace('TPUB');
-    $tpub_vocab->setURL('cv/lookup/TPUB');
     $ontologies[] = [
-      'vocabulary' => $tpub_vocab,
-      'idSpace' => $tpub_idspace,
+      'vocabulary' => $this->getVocabulary('tripal_pub'),
+      'idSpace' => $this->getIdSpace('TPUB'),
       'path' => '{tripal_chado}/files/tpub.obo',
       'auto_load' => TRUE,
     ];
 
     // Iterate through each ontology and install them with the OBO Importer.
     foreach ($ontologies as $ontology) {
-      $obo_id = $this->addOntologyRecord($ontology);
+      $obo_id = $this->insertOntologyRecord($ontology);
       if ($ontology['auto_load']) {
-         $this->logger->notice("  Importing " . $ontology['idSpace']->getDescription());
-         $importer_manager = \Drupal::service('tripal.importer');
-         $obo_importer = $importer_manager->createInstance('chado_obo_loader');
-         $obo_importer->create(['obo_id' => $obo_id]);
-         $obo_importer->run();
-         $obo_importer->postRun();
+        $this->logger->notice("Importing " . $ontology['idSpace']->getDescription());
+        $importer_manager = \Drupal::service('tripal.importer');
+        $obo_importer = $importer_manager->createInstance('chado_obo_loader');
+        $obo_importer->create(['obo_id' => $obo_id]);
+        $obo_importer->run();
+        $obo_importer->postRun();
       }
     }
   }
+
+
+
 
   /**
    * A helper function for inserting OBO recrods into the `tripal_cv_obo` table.
@@ -1064,7 +3275,7 @@ class ChadoPreparer extends ChadoTaskBase {
    * @return int
    *   The Id of the inserted OBO record.
    */
-  private function addOntologyRecord($ontology) {
+  private function insertOntologyRecord($ontology) {
 
     $name = $ontology['idSpace']->getDescription();
 
@@ -1100,361 +3311,160 @@ class ChadoPreparer extends ChadoTaskBase {
   }
 
   /**
-   * Creates default content types.
-   */
-  protected function contentTypes() {
-    $this->generalContentTypes();
-    $this->genomicContentTypes();
-    $this->geneticContentTypes();
-    $this->germplasmContentTypes();
-    $this->expressionContentTypes();
-  }
-
-  /**
-   * Helper: Create a given set of types.
+   * Create a new Content Type.
    *
-   * @param $types
-   *   An array of types to be created. The key is used to link the type to
-   *   it's term and the value is an array of details to be passed to the
-   *   create() method for Tripal Entity Types. Some keys should be:
-   *    - id: the integer id for this type; this will go away since it
-   *        should be automatic.
-   *    - name: the machine name for this type. It should be bio_data_[id]
-   *        where [id] matches the integer id above. Also should be automatic.
-   *    - label: a human-readable label for the content type.
-   *    - category: a grouping string to categorize content types in the UI.
-   *    - help_text: a single sentence describing the content type -usually
-   *        the default is the term definition.
-   * @param $terms
-   *   An array of terms which must already exist where the key maps to a
-   *   content type in the $types array. The value for each item is an array of
-   *   details to be passed to the term creation API. Some keys should be:
-   *    - accession: the unique identifier for the term (i.e. 2945)
-   *    - vocabulary:
-   *       - namespace: The name of the vocabulary (i.e. EDAM).
-   *       - idspace: the id space of the term (i.e. operation).
    */
-  protected function createGivenContentTypes($types, $terms) {
-    foreach($terms as $key => $term_details) {
-      $type_details = $types[$key];
+  private function createContentType($details) {
 
-      $this->logger->notice("  -- Creating " . $type_details['label'] . " (" . $type_details['name'] . ")...");
+    // Get the next bio_data_x index number.
+    $cid = 'chado_bio_data_index';
+    $next_index = \Drupal::cache()->get($cid, 0)->data + 1;
+    $details['id'] = $next_index;
+    $details['name'] = 'bio_data_' . $next_index;
 
-      // TODO: Create the term once the API is upgraded.
-      // $term = \Drupal::service('tripal.tripalTerm.manager')->getTerms($term_details);
+    $term = $details['term'];
+    if (!array_key_exists('term', $details) or !$details['term']) {
+      $this->logger->error(t('Creation of content type, "@type", failed. No term provided.',
+          ['@type' => $details['label']]));
+      return;
+    }
+    if (!$term->isValid()) {
+      $this->logger->error(t('Creation of content type, "@type", failed. The provided term, "@term", was not valid.',
+          ['@type' => $details['label'], '@term' => $term->getTermId()]));
+      return;
+    }
 
-      // TODO: Set the term in the type details.
-      if (is_object($term)) {
-        // $type_details['term_id'] = $term->getID();
-        if (!array_key_exists($type_details, 'help_text')) {
-          // $type_details['help_text'] = $term->getDefinition();
-        }
-      }
-      else {
-        $this->logger->warning("\tNo term attached -waiting on API update.");
-      }
+    // Check if the type already exists.
+    $entityType = \Drupal::entityTypeManager()
+      ->getStorage('tripal_entity_type')
+      ->loadByProperties(['label' => $details['label']]);
+    if ($entityType) {
+      $this->logger->notice(t('Skipping content type, "@type", as it already exists.',
+          ['@type' => $details['label']]));
+      return;
+    }
 
-      // Check if the type already exists.
-      // TODO: use term instead of label once it's available.
-      $filter = ['label' => $type_details['label'] ];
-      $exists = \Drupal::entityTypeManager()
-        ->getStorage('tripal_entity_type')
-        ->loadByProperties($filter);
-
-      // Create the Type.
-      if (empty($exists)) {
-        $tripal_type = TripalEntityType::create($type_details);
-        if (is_object($tripal_type)) {
-          $tripal_type->save();
-          $this->logger->notice("\tSaved successfully.");
-        }
-        else {
-          $this->logger->error("\tCreation Failed! Details provided were: " . print_r($type_details));
-        }
-      }
-      else {
-        $this->logger->notice("\tSkipping as the content type already exists.");
-      }
+    $entityType = TripalEntityType::create($details);
+    if (is_object($entityType)) {
+      $entityType->save();
+      $this->logger->notice(t('Content type, "@type", created..',
+          ['@type' => $details['label']]));
+      \Drupal::cache()->set($cid, $next_index);
+    }
+    else {
+      $this->logger->error(t('Creation of content type, "@type", failed. The provided provided were: ',
+          ['@type' => $details['label']]) . print_r($details));
     }
   }
 
+
+
   /**
    * Creates the "General" category of content types.
-   *
-   * @code
-   $terms[''] =[
-     'accession' => '',
-     'vocabulary' => [
-       'idspace' => '',
-     ],
-   ];
-   $types['']= [
-     'id' => ,
-     'name' => '',
-     'label' => '',
-     'category' => 'General',
-   ];
-   * @endcode
    */
-  protected function generalContentTypes() {
+  private function createGeneralContentTypes() {
 
-    // The 'Organism' entity type. This uses the obi:organism term.
-    $terms['organism'] =[
-      'accession' => '0100026',
-      'vocabulary' => [
-        'idspace' => 'OBI',
-      ],
-    ];
-    $types['organism']= [
-      'id' => 1,
-      'name' => 'bio_data_1',
+    $this->createContentType([
       'label' => 'Organism',
+      'term' => $this->getTerm('OBI', '0100026'),
       'category' => 'General',
-    ];
+    ]);
 
-    // The 'Analysis' entity type. This uses the EDAM:analysis term.
-    $terms['analysis'] = [
-      'accession' => '2945',
-      'vocabulary' => [
-        'namespace' => 'EDAM',
-        'idspace' => 'operation',
-      ],
-    ];
-    $types['analysis'] = [
-      'id' => 2,
-      'name' => 'bio_data_2',
+    $this->createContentType([
       'label' => 'Analysis',
+      'term' => $this->getTerm('operation', '2945', 'EDAM'),
       'category' => 'General',
-    ];
+    ]);
 
-    // The 'Project' entity type. bio_data_3
-    $terms['project'] =[
-      'accession' => 'C47885',
-      'vocabulary' => [
-        'idspace' => 'NCIT',
-      ],
-    ];
-    $types['project']= [
-      'id' => 3,
-      'name' => 'bio_data_3',
+    $this->createContentType([
       'label' => 'Project',
+      'term' => $this->getTerm('NCIT', 'C47885'),
       'category' => 'General',
-    ];
+    ]);
 
-    // The 'Study' entity type. bio_data_4
-    $terms['study'] =[
-      'accession' => '001066',
-      'vocabulary' => [
-        'idspace' => 'SIO',
-      ],
-    ];
-    $types['study']= [
-      'id' => 4,
-      'name' => 'bio_data_4',
+    $this->createContentType([
       'label' => 'Study',
+      'term' => $this->getTerm('SIO', '001066'),
       'category' => 'General',
-    ];
+    ]);
 
-    // The 'Contact' entity type. bio_data_5
-    $terms['contact'] =[
-      'accession' => 'contact',
-      'vocabulary' => [
-        'idspace' => 'local',
-      ],
-    ];
-    $types['contact']= [
-      'id' => 5,
-      'name' => 'bio_data_5',
+    $this->createContentType([
       'label' => 'Contact',
+      'term' => $this->getTerm('local', 'contact'),
       'category' => 'General',
-    ];
+    ]);
 
-    // The 'Publication' entity type. bio_data_6
-    $terms['publication'] =[
-      'accession' => '0000002',
-      'vocabulary' => [
-        'idspace' => 'TPUB',
-      ],
-    ];
-    $types['publication']= [
-      'id' => 6,
-      'name' => 'bio_data_6',
+    $this->createContentType([
       'label' => 'Publication',
+      'term' => $this->getTerm('TPUB', '0000002'),
       'category' => 'General',
-    ];
+    ]);
 
-    // The 'Protocol' entity type. bio_data_7
-    $terms['protocol'] =[
-      'accession' => '00101',
-      'vocabulary' => [
-        'idspace' => 'sep',
-      ],
-    ];
-    $types['protocol']= [
-      'id' => 7,
-      'name' => 'bio_data_7',
+    $this->createContentType([
       'label' => 'Protocol',
+      'term' => $this->getTerm('sep', '00101'),
       'category' => 'General',
-    ];
-
-    $this->createGivenContentTypes($types, $terms);
+    ]);
   }
 
   /**
    * Creates the "Genomic" category of content types.
-   *
-   * @code
-   $terms[''] =[
-     'accession' => '',
-     'vocabulary' => [
-       'idspace' => '',
-     ],
-   ];
-   $types['']= [
-     'id' => ,
-     'name' => '',
-     'label' => '',
-     'category' => 'Genomic',
-   ];
-   * @endcode
    */
-  protected function genomicContentTypes() {
+  private function createGenomicContentTypes() {
 
-    // The 'Gene' entity type. This uses the sequence:gene term.
-    $terms['gene'] = [
-      'accession' => '0000704',
-      'vocabulary' => [
-        'namespace' => 'sequence',
-        'idspace' => 'SO',
-      ],
-    ];
-    $types['gene'] = [
-      'id' => 8,
-      'name' => 'bio_data_8',
+    $this->createContentType([
       'label' => 'Gene',
+      'term' => $this->getTerm('SO', '0000704'),
       'category' => 'Genomic',
-    ];
+    ]);
 
-    // the 'mRNA' entity type. bio_data_9
-    $terms['mRNA'] =[
-      'accession' => '0000234',
-      'vocabulary' => [
-        'idspace' => 'SO',
-      ],
-    ];
-    $types['mRNA']= [
-      'id' => 9,
-      'name' => 'bio_data_9',
+    $this->createContentType([
       'label' => 'mRNA',
+      'term' => $this->getTerm('SO', '0000234'),
       'category' => 'Genomic',
-    ];
+    ]);
 
-    // The 'Phylogenetic tree' entity type. bio_data_10
-    $terms['phylo'] =[
-      'accession' => '0872',
-      'vocabulary' => [
-        'idspace' => 'data',
-      ],
-    ];
-    $types['phylo']= [
-      'id' => 10,
-      'name' => 'bio_data_10',
+    $this->createContentType([
       'label' => 'Phylogenetic Tree',
+      'term' => $this->getTerm('data', '0872', 'EDAM'),
       'category' => 'Genomic',
-    ];
+    ]);
 
-    // The 'Physical Map' entity type. bio_data_11
-    $terms['map'] =[
-      'accession' => '1280',
-      'vocabulary' => [
-        'idspace' => 'data',
-      ],
-    ];
-    $types['map']= [
-      'id' => 11,
-      'name' => 'bio_data_11',
+    $this->createContentType([
       'label' => 'Physical Map',
+      'term' => $this->getTerm('data', '1280', 'EDAM'),
       'category' => 'Genomic',
-    ];
+    ]);
 
-    // The 'DNA Library' entity type. bio_data_12
-    $terms['library'] =[
-      'accession' => 'C16223',
-      'vocabulary' => [
-        'idspace' => 'NCIT',
-      ],
-    ];
-    $types['library']= [
-      'id' => 12,
-      'name' => 'bio_data_12',
+    $this->createContentType([
       'label' => 'DNA Library',
+      'term' => $this->getTerm('NCIT', 'C16223'),
       'category' => 'Genomic',
-    ];
+    ]);
 
-    // The 'Genome Assembly' entity type. bio_data_13
-    $terms['assembly'] =[
-      'accession' => '0525',
-      'vocabulary' => [
-        'idspace' => 'operation',
-      ],
-    ];
-    $types['assembly']= [
-      'id' => 13,
-      'name' => 'bio_data_13',
+    $this->createContentType([
       'label' => 'Genome Assembly',
+      'term' => $this->getTerm('operation', '0525', 'EDAM'),
       'category' => 'Genomic',
-    ];
+    ]);
 
-    // The 'Genome Annotation' entity type. bio_data_14
-    $terms['annotation'] =[
-      'accession' => '0362',
-      'vocabulary' => [
-        'idspace' => 'operation',
-      ],
-    ];
-    $types['annotation']= [
-      'id' => 14,
-      'name' => 'bio_data_14',
-      'label' => 'Genome Assembly',
+    $this->createContentType([
+      'label' => 'Genome Annotation',
+      'term' => $this->getTerm('operation', '0362', 'EDAM'),
       'category' => 'Genomic',
-    ];
+    ]);
 
-    // The 'Genome Project' entity type. bio_data_15
-    $terms['genomeproject'] =[
-      'accession' => 'Genome Project',
-      'vocabulary' => [
-        'idspace' => 'local',
-      ],
-    ];
-    $types['genomeproject']= [
-      'id' => 15,
-      'name' => 'bio_data_15',
+    $this->createContentType([
       'label' => 'Genome Project',
+      'term' => $this->getTerm('local', 'Genome Project'),
       'category' => 'Genomic',
-    ];
-
-    $this->createGivenContentTypes($types, $terms);
+    ]);
   }
 
   /**
    * Creates the "Genetic" category of content types.
-   *
-   * @code
-   $terms[''] =[
-     'accession' => '',
-     'vocabulary' => [
-       'idspace' => '',
-     ],
-   ];
-   $types['']= [
-     'id' => ,
-     'name' => '',
-     'label' => '',
-     'category' => 'Genetic',
-   ];
-   * @endcode
    */
-  protected function geneticContentTypes() {
+  private function createGeneticContentTypes() {
 
     // The 'Genetic Map' entity type. bio_data_16
     $terms['map'] =[
@@ -1531,23 +3541,8 @@ class ChadoPreparer extends ChadoTaskBase {
 
   /**
    * Creates the "Germplasm" category of content types.
-   *
-   * @code
-   $terms[''] =[
-     'accession' => '',
-     'vocabulary' => [
-       'idspace' => '',
-     ],
-   ];
-   $types['']= [
-     'id' => ,
-     'name' => '',
-     'label' => '',
-     'category' => 'Germplasm',
-   ];
-   * @endcode
    */
-  protected function germplasmContentTypes() {
+  private function createGermplasmContentTypes() {
 
     // The 'Phenotypic Trait' entity type. bio_data_28
     $terms['trait'] =[
@@ -1625,23 +3620,8 @@ class ChadoPreparer extends ChadoTaskBase {
 
   /**
    * Creates the "Expression" category of content types.
-   *
-   * @code
-   $terms[''] =[
-     'accession' => '',
-     'vocabulary' => [
-       'idspace' => '',
-     ],
-   ];
-   $types['']= [
-     'id' => ,
-     'name' => '',
-     'label' => '',
-     'category' => 'Expression',
-   ];
-   * @endcode
    */
-  protected function expressionContentTypes() {
+  private function createExpressionContentTypes() {
 
     // The 'biological sample' entity type. bio_data_25
     $terms['sample'] =[

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -1528,7 +1528,7 @@ class ChadoPreparer extends ChadoTaskBase {
     $format_idspace = $this->getIdSpace('format');
     $format_idspace->setDescription('A defined way or layout of representing and structuring data in a computer file, blob, string, message, or elsewhere. The main focus in EDAM lies on formats as means of structuring data exchanged between different tools or resources.');
     $format_idspace->setURLPrefix("http://edamontology.org/{db}_{accession}");
-    $format_idspace->setDefaultVocabulary('foaf');
+    $format_idspace->setDefaultVocabulary('EDAM');
 
     $operation_idspace = $this->getIdSpace('operation');
     $operation_idspace->setDescription('A function that processes a set of inputs and results in a set of outputs, or associates arguments (inputs) with values (outputs). Special cases are: a) An operation that consumes no input (has no input arguments).');

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -3236,11 +3236,12 @@ class ChadoPreparer extends ChadoTaskBase {
     // Iterate through each ontology and install them with the OBO Importer.
     foreach ($ontologies as $ontology) {
       $obo_id = $this->insertOntologyRecord($ontology);
+      $schema_name = $this->outputSchemas[0]->getSchemaName();
       if ($ontology['auto_load']) {
         $this->logger->notice("Importing " . $ontology['idSpace']->getDescription());
         $importer_manager = \Drupal::service('tripal.importer');
         $obo_importer = $importer_manager->createInstance('chado_obo_loader');
-        $obo_importer->create(['obo_id' => $obo_id]);
+        $obo_importer->create(['obo_id' => $obo_id, 'schema_name' => $schema_name]);
         $obo_importer->run();
         $obo_importer->postRun();
       }

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -156,8 +156,7 @@ class ChadoPreparer extends ChadoTaskBase {
       $this->setProgress(0.2);
       $this->logger->notice("Loading ontologies...");
       $this->addOntologies();
-      $this->logger->notice('!!!! Uncomment the importOntologies() function !!!');
-      //$this->importOntologies();
+      $this->importOntologies();
 
       $this->setProgress(0.3);
       $this->logger->notice('Populating materialized view cv_root_mview...');


### PR DESCRIPTION
Issue #212

This PR updates the `ChadoPrepare` task so that it creates content types using Terms instead of only hard-coded labels.  

## Changes Added:

To make this happen I made the following changes.

1.  Added functions for importing all of the default ontologies and terms. 
  - You'll notice in the `ChadoPrepare` task that there are a lot of `addOntologyXXXX` functions. One for each ontology. Each one of these functions adds the IdSpace, Vocabulary and Terms that are required to get content types up and running. 
  -  There are more ontologies and terms than just what is needed for the content types. I actually added all of the terms used to map columns and tables of Chado in the semantic web part. But, I did not add the support for semantic web.  I just added all the terms since I was at it.
2.  Update the function for creating the entity types to be a bit more error tolerant and to automate name creation of the entity types so that it's not up to the programmer to hard-code it.
3. Minor bug fixes also included:
  - I updated the `ChadoIdSpace` and `ChadoVocabulary` classes so their error messages were a bit more informative. 
  - I fixed a bug in the `ChadoIdSpace` where it wasn't getting the default vocabulary if the IdSpace was loaded.  I could have issued a new PR for that, but it was such a small change I figured it could be looked at easy enough and this code would break if it wasn't for that fix.
  - I fixed a bug in the `ChadoIdSpace` where it now checks if the term is valid in the constructor.   It could be a perfectly good IdSpace but the is_valid flag didn't get set.

I don't think the creation of Entity Types is done, but I'm not familiar with the design to know what to do after this.  The term is being passed in when creating the entity type but I'm not sure if that's correct. So, I'm stopping the code updates until it can be looked at by @4ctrl-alt-del and @laceysanderson.   

## How to Test

1. Start with a brand new Tripal installation or drop the `chado` schema just to get a fresh start and reinstall the `tripal` and `tripal_chado` modules.
2. Install a new version of Chado
3. Run the prepare step.  You should see all of the content types get created.