### PR TITLE
Allow composer plugin needed for 9.2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,7 @@ RUN export COMPOSER_MEMORY_LIMIT=-1 && export COMPOSER_NO_INTERACTION=1 \
   && composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true \
   && composer config --no-plugins allow-plugins.drupal/core-project-message true \
   && composer config --no-plugins allow-plugins.drupal/console-extend-plugin true \
++  && composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true \
   && rm composer.lock \
   && composer require --dev drupal/core:${drupalversion} ${composerpackages}
 


### PR DESCRIPTION
Building docker is failing on 9.2.x due to a composer issue:
```
  - Installing squizlabs/php_codesniffer (3.7.1): Extracting archive
In PluginManager.php line 762:
  dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin w  
  hich is blocked by your allow-plugins config. You may add it to the list if  
   you consider it safe.                                                       
  You can run "composer config --no-plugins allow-plugins.dealerdirect/phpcod  
  esniffer-composer-installer [true|false]" to enable it (true) or disable it  
   explicitly and suppress this exception (false)                              
  See https://getcomposer.org/allow-plugins
```

This PR should solve this error.