### PR TITLE
Upgrade docker to PHP 8.0

### DIFF
--- a/.github/workflows/phpunit-optional.yml
+++ b/.github/workflows/phpunit-optional.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - drupalversion: '9.1.x-dev'
-            label: 'Backwards Compatibility'
+          # - drupalversion: '9.1.x-dev'
+          #   label: 'Backwards Compatibility'
           - drupalversion: '9.4.x-dev'
             label: 'Future Version'
     # Give the builds names so we can tell them apart

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,7 +203,7 @@ RUN service apache2 start \
 ## Configuration files & Activation script
 RUN mv /app/tripaldocker/init_scripts/supervisord.conf /etc/supervisord.conf \
   && mv /app/tripaldocker/default_files/000-default.conf /etc/apache2/sites-available/000-default.conf \
-  && echo "\$settings["trusted_host_patterns"] = [ '^localhost$', '^127\.0\.0\.1$' ];" >> /var/www/drupal9/web/sites/default/settings.php \
+  && echo "\$settings['trusted_host_patterns'] = [ '^localhost$', '^127\.0\.0\.1$' ];" >> /var/www/drupal9/web/sites/default/settings.php \
   && mv /app/tripaldocker/init_scripts/init.sh /usr/bin/init.sh \
   && chmod +x /usr/bin/init.sh \
   && mv /app/tripaldocker/default_files/xdebug/xdebug_toggle.sh /usr/bin/xdebug_toggle.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -192,9 +192,9 @@ RUN service apache2 start \
   && mkdir -p /var/www/drupal9/web/modules/contrib \
   && cp -R /app /var/www/drupal9/web/modules/contrib/tripal \
   && composer require drupal/devel drupal/devel_php \
-  # && vendor/bin/drush en devel tripal ${modules} -y \
-  # && vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
-  # && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema} \
+  && vendor/bin/drush en devel tripal ${modules} -y \
+  && vendor/bin/drush trp-install-chado --schema-name=${chadoschema} \
+  && vendor/bin/drush trp-prep-chado --schema-name=${chadoschema} \
   && service apache2 stop \
   && service postgresql stop
 

--- a/docs/install/docker.rst
+++ b/docs/install/docker.rst
@@ -7,14 +7,13 @@ Software Stack
 --------------
 
 Currently we have the following installed:
- - Debian Buster(10)
- - PHP 7.3.33 with extensions needed for Drupal (Memory limit 1028M)
- - Apache 2.4.38
- - PostgreSQL 11.14 (Debian 11.14-0+deb10u1)
- - Composer 2.2.6
- - Drupal Console 1.9.8
- - Drush 10.6.2
- - Drupal 9.1.x-dev downloaded using composer (or as specified by drupalversion argument).
+ - Debian Bullseye(11)
+ - PHP 8.0.21 with extensions needed for Drupal (Memory limit 1028M)
+ - Apache 2.4.54
+ - PostgreSQL 13.7 (Debian 13.7-0+deb11u1)
+ - Composer 2.3.10
+ - Drush 11.1.1
+ - Drupal 9.3.x-dev downloaded using composer (or as specified by drupalversion argument).
  - Xdebug 3.0.1
 
 Quickstart
@@ -205,13 +204,13 @@ Debugging
 Xdebug: Overview
 ^^^^^^^^^^^^^^^^
 There is an optional Xdebug configuration available for use in debugging Tripal 4.
-It is disabled by default. Currently, the Docker ships with three modes available: 
+It is disabled by default. Currently, the Docker ships with three modes available:
 
 `Develop <https://xdebug.org/docs/develop>`_
   Adds developer aids to provide "better error messages and obtain more information from PHP's built-in functions".
 
 `Debug <https://xdebug.org/docs/step_debug>`_
-  Adds the ability to interactively walk through the code. 
+  Adds the ability to interactively walk through the code.
 
 `Profile <https://xdebug.org/docs/profiler>`_
   Adds the ability to "find bottlenecks in your script and visualize those with an external tool".
@@ -221,7 +220,7 @@ To enable Xdebug, issue the following command:
 .. code::
 
   docker exec --workdir=/var/www/drupal9/web/modules/contrib/tripal t4d8 xdebug_toggle.sh
-  
+
 This will toggle the Xdebug configuration file and restart Apache. You should use this command to disable Xdebug if it is enabled prior to running PHPUnit Tests as it seriously impacts test run duration (approximately 8 times longer).
 
 
@@ -253,15 +252,15 @@ A new configuration should be made using PHP. The following options can be used 
     ]
   }
 
-The important parameter here is `pathMappings` which will allow Xdebug and your IDE know which paths on the host and in the Docker VM coorespond to eachother. 
-The first path listed is the one within the Docker and should point to the Tripal directory. The seocnd path is the one on your local host machine where you 
+The important parameter here is `pathMappings` which will allow Xdebug and your IDE know which paths on the host and in the Docker VM coorespond to eachother.
+The first path listed is the one within the Docker and should point to the Tripal directory. The seocnd path is the one on your local host machine where you
 installed the repo and built the Docker image. If you followed the instructions above, this should be in your user folder under `~/Dockers/t4d8`.
 
 9003 is the default port and should only be changed if 9003 is already in use on your host system.
 
 With this configuration saved, the Play button can be pressed to enable this configuration and have your IDE listen for incoming connections from the Xdebug PHP extension.
 
-More info can be found for VS Code's step debugging facility in `VS Code's documentation <https://code.visualstudio.com/docs/editor/debugging>`_. 
+More info can be found for VS Code's step debugging facility in `VS Code's documentation <https://code.visualstudio.com/docs/editor/debugging>`_.
 
 Xdebug: Profiling
 ^^^^^^^^^^^^^^^^^

--- a/tripal/src/Element/HTML5File.php
+++ b/tripal/src/Element/HTML5File.php
@@ -194,7 +194,7 @@ class HTML5File extends FormElement {
   /**
    * {@inheritdoc}
    */
-  public static function valueCallback(&$element, $input = FALSE, FormStateInterface $form_state) {
+  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
     if ($input) {
       if (is_array($input)) {
         $name = HTML5File::getBaseKey($element);

--- a/tripal/src/Form/Register.php
+++ b/tripal/src/Form/Register.php
@@ -162,7 +162,8 @@ class Register implements FormInterface {
       $default_num_funding = max(count($funding_values), 1);
     }
     $num_funding = $form_state->getValue(['funding', 'num'], $default_num_funding);
-    if ($form_state->getTriggeringElement()['#name'] == 'add_funding') {
+    $triggeringElement = $form_state->getTriggeringElement();
+    if (!empty($triggeringElement) && ($triggeringElement['#name'] == 'add_funding')) {
       $num_funding++;
     }
     $form_state->setValue(['funding', 'num'], $num_funding);

--- a/tripal/src/TripalDBX/pg-clone-schema/clone_schema.sql
+++ b/tripal/src/TripalDBX/pg-clone-schema/clone_schema.sql
@@ -72,7 +72,7 @@ $$
     IF (v_table_oid IS NULL) THEN
       RAISE EXCEPTION 'table does not exist';
     END IF;
-    
+
     -- start the create definition
     v_table_ddl := 'CREATE TABLE ' || in_schema || '.' || in_table || ' (' || E'\n';
 
@@ -120,7 +120,7 @@ $$
       JOIN pg_catalog.pg_namespace nsp ON nsp.oid = connamespace
       WHERE nsp.nspname = in_schema
       AND rel.relname = in_table
-      ORDER BY type_rank
+      ORDER BY type_rank ASC, con.conname ASC
     LOOP
       IF v_constraintrec.type_rank = 1 THEN
           v_primary := True;
@@ -147,6 +147,7 @@ $$
       SELECT indexdef, indexname
       FROM pg_indexes
       WHERE (schemaname, tablename) = (in_schema, in_table)
+      ORDER BY indexname ASC
     LOOP
       IF v_indexrec.indexname = v_constraint_name THEN
           continue;
@@ -995,7 +996,7 @@ BEGIN
         AND indexdef ~* ('(^|\W)' || quote_ident(source_schema) || '\.')
     LOOP
       buffer := regexp_replace(buffer::text, '(^|\W)' || quote_ident(source_schema) || '\.', '\1' || quote_ident(dest_schema) || '.', 'gis');
-     
+
       IF ddl_only THEN
         -- Drop previous definition.
         RAISE INFO '%', 'DROP INDEX ' || quote_ident(dest_schema) || '.' || quote_ident(buffer2) || ';';

--- a/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
+++ b/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
@@ -548,9 +548,9 @@ class SchemaTest extends KernelTestBase {
   CONSTRAINT testtable_c1 UNIQUE (fieldbigint, fieldsmallint),
   CONSTRAINT testtable_foreign_id_fkey FOREIGN KEY (foreign_id) REFERENCES othertesttable(id) ON DELETE SET NULL DEFERRABLE INITIALLY DEFERRED
 );
-CREATE INDEX testtable_idx1 ON $test_schema.testtable USING btree (foreign_id);
-CREATE UNIQUE INDEX testtable_c2 ON $test_schema.testtable USING btree (fieldbigint, fieldsmallint);
 CREATE UNIQUE INDEX testtable_c1 ON $test_schema.testtable USING btree (fieldbigint, fieldsmallint);
+CREATE UNIQUE INDEX testtable_c2 ON $test_schema.testtable USING btree (fieldbigint, fieldsmallint);
+CREATE INDEX testtable_idx1 ON $test_schema.testtable USING btree (foreign_id);
 COMMENT ON TABLE $test_schema.testtable IS 'Some long description
 on multiple lines.';
 ";

--- a/tripal_chado/src/Commands/ChadoManageCommands.php
+++ b/tripal_chado/src/Commands/ChadoManageCommands.php
@@ -98,9 +98,9 @@ class ChadoManageCommands extends DrushCommands {
     }
     else {
       throw new \Exception(dt(
-        'Unable to prepare Crupal + Chado in {schema}',
+        'Unable to prepare Drupal + Chado in @schema',
         [
-          'schema' => $options['schema-name'],
+          '@schema' => $options['schema-name'],
         ]
       ));
     }

--- a/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
+++ b/tripal_chado/src/Plugin/TripalImporter/OBOImporter.php
@@ -2380,7 +2380,7 @@ class OBOImporter extends ChadoImporterBase {
     // Make sure there are CV records for all namespaces.
     $message = t('Found the following namespaces: @namespaces.',
       ['@namespaces' => implode(', ', array_keys($this->obo_namespaces))]);
-    foreach ($this->obo_namespaces as $namespace => $cv->cv_id) {
+    foreach ($this->obo_namespaces as $namespace => $cv) {
       $this->insertChadoCv($namespace);
     }
     $this->logger->notice($message->getUntranslatedString());

--- a/tripal_chado/src/api/tripal_chado.cv.api.inc
+++ b/tripal_chado/src/api/tripal_chado.cv.api.inc
@@ -485,7 +485,7 @@ function chado_insert_cvterm($term, $options = [], $schema_name = 'chado') {
   if (isset($options['update_existing'])) {
     $update = $options['update_existing'];
   }
- 
+
   $name = $id; // default value
   if (array_key_exists('name', $term)) {
     $name = $term['name'];
@@ -538,7 +538,7 @@ function chado_insert_cvterm($term, $options = [], $schema_name = 'chado') {
     $cv = new stdClass();
     $cv->cv_id = $row_cv->cv_id;
   }
-  
+
   // If CV does not exist
   if (!$cv) {
     $cv = chado_insert_cv($cvname, '', [], $schema_name);
@@ -911,7 +911,7 @@ function chado_autocomplete_cvterm($cv_id, $string = '') {
  *
  * @ingroup tripal_chado_cv_api
  */
-function chado_associate_cvterm($basetable, $record_id, $cvterm, $options = [], $schema_name) {
+function chado_associate_cvterm($basetable, $record_id, $cvterm, $options, $schema_name) {
   $linking_table = $basetable . '_cvterm';
   $foreignkey_name = $basetable . '_id';
 

--- a/tripal_chado/src/api/tripal_chado.query.api.inc
+++ b/tripal_chado/src/api/tripal_chado.query.api.inc
@@ -1754,6 +1754,7 @@ function chado_query($sql, $args = [], $options = [], $chado_schema_name = NULL)
 
   // Check if Chado is within the same database as Drupal (i.e. local).
   $is_local = chado_is_local(FALSE, $chado_schema_name);
+
   // Validation:
   // -- SQL should be a string.
   if (!is_string($sql)) {
@@ -1812,7 +1813,7 @@ function chado_query($sql, $args = [], $options = [], $chado_schema_name = NULL)
     $matches = [];
     if (preg_match_all('/\{(.*?)\}/', $sql, $matches)) {
       $matches = $matches[1];
-      $chado_tables = array_unique(array_keys(chado_get_table_names(TRUE)));
+      $chado_tables = chado_get_table_names(TRUE);
       foreach ($matches as $match) {
         if (in_array(strtolower($match), $chado_tables)) {
           $sql = preg_replace("/\{$match\}/", $chado_schema_name . '.' . $match, $sql);
@@ -1848,9 +1849,11 @@ function chado_query($sql, $args = [], $options = [], $chado_schema_name = NULL)
     // tables with featureloc must automaticaly have the chado schema set as
     // active to find.
     if (preg_match('/' . $chado_schema_name . '.featureloc/i', $sql) or preg_match('/' . $chado_schema_name . '.feature/i', $sql)) {
-      $previous_db = chado_set_active('chado');
+      $previous_db = chado_set_active($chado_schema_name);
       try {
-        $results = \Drupal::database()->query($sql, $args, $options);
+        $connection = \Drupal::service('tripal_chado.database');
+        $connection->setSchemaName($chado_schema_name);
+        $results = $connection->query($sql, $args, $options);
         chado_set_active($previous_db);
       } catch (Exception $e) {
         chado_set_active($previous_db);
@@ -1860,7 +1863,9 @@ function chado_query($sql, $args = [], $options = [], $chado_schema_name = NULL)
     // For all other tables we should have everything in scope so just run the
     // query.
     else {
-      $results = \Drupal::database()->query($sql, $args, $options);
+      $connection = \Drupal::service('tripal_chado.database');
+      $connection->setSchemaName($chado_schema_name);
+      $results = $connection->query($sql, $args, $options);
     }
   }
   // Check for any cross schema joins (ie: both drupal and chado tables
@@ -1877,8 +1882,10 @@ function chado_query($sql, $args = [], $options = [], $chado_schema_name = NULL)
     // switch to another database.
     else {
       $previous_db = chado_set_active('chado', $chado_schema_name);
-      $results = \Drupal::database()->query($sql, $args, $options);
-      chado_set_active($previous_db, $chado_schema_name);    
+      $connection = \Drupal::service('tripal_chado.database');
+      $connection->setSchemaName($chado_schema_name);
+      $results = $connection->query($sql, $args, $options);
+      chado_set_active($previous_db, $chado_schema_name);
     }
   }
 

--- a/tripal_chado/src/api/tripal_chado.schema.api.inc
+++ b/tripal_chado/src/api/tripal_chado.schema.api.inc
@@ -490,7 +490,8 @@ function chado_get_table_names($include_custom = NULL, $chado_schema = NULL) {
 
   // Create a new ChadoSchema instance and use it to get the table names.
   $chado_schema = new \Drupal\tripal_chado\api\ChadoSchema(NULL, $chado_schema);
-  return $chado_schema->getTableNames($include_custom);
+  $tables = $chado_schema->getTableNames($include_custom);
+  return array_combine($tables, $tables);
 }
 
 /**


### PR DESCRIPTION
Full completion of Issue #250 

Removed support for 9.1.x and upgraded Docker OS + PostgreSQL version as well.

This PR will be merged if tests pass on 9.2.x and 9.3.x with no new errors on 9.4.x (this Drupal version isn't passing on master due to problems in Tripal DBX).

If you run into any issues with Tripal on the main branch then please file an issue :-) as we don't have automated testing for everything yet.