### PR TITLE
Fix the Tripal DBX tests for 9.4.x

### DIFF
--- a/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
+++ b/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
@@ -370,56 +370,50 @@ class SchemaTest extends KernelTestBase {
     $this->assertFalse($exists, 'Function "dummy()" does not exist.');
 
     // Create a table.
-    // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Schema.php/function/Schema%3A%3AcreateTable/9.2.x
     $scmock->createTable(
-      'new_table',
-      [
-        "fields" => [
-          "thing" => [
-            "type" => "text",
-            "not null" => TRUE,
-            "pgsql_type" => "integer",
-          ],
-        ],
-      ]
-    );
-    $exists = $scmock->tableExists('new_table');
-    $this->assertTrue($exists, 'Table "new_table" exists.');
+          'table_1',
+          [
+            "fields" => [
+              "thing" => [
+                "type" => "text",
+                "not null" => TRUE,
+                "pgsql_type" => "integer",
+              ],
+            ],
+          ]
+        );
+    $exists = $scmock->tableExists('table_1');
+    $this->assertTrue($exists, 'Table "table_1" was created.');
 
     // Rename table.
-    // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Schema.php/function/Schema%3A%3ArenameTable/9.2.x
-    // Not working: $scmock->renameTable('new_table', 'newtable');
-    // Not working: $exists = $scmock->tableExists('new_table');
-    // Not working: $this->assertFalse($exists, 'Table "new_table" renamed into something else.');
-    // Not working: $exists = $scmock->tableExists('newtable');
-    // Not working: $this->assertTrue($exists, 'Table "newtable" is the new table name.');
+    $scmock->renameTable('table_1', 'table_1_renamed');
+    $exists = $scmock->tableExists('table_1');
+    $this->assertFalse($exists, 'Table "table_1" renamed into something else as it no longer exists.');
+    $exists = $scmock->tableExists('table_1_renamed');
+    $this->assertTrue($exists, 'Table "table_1_renamed" is the new table name since it does exist.');
 
     // Change field.
-    // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Schema.php/function/Schema%3A%3AchangeField/9.2.x
-    /* Currently not working
     $scmock->changeField(
-      'newtable',
+      'table_1_renamed',
       'thing',
-      'thingnew',
+      'thing_renamed',
       [
         "type" => "text",
         "not null" => FALSE,
         "pgsql_type" => "bigint",
       ]
     );
-    $exists = $scmock->fieldExists('newtable', 'thingnew');
-    $this->assertTrue($exists, 'Field "newtable.thingnew" exists.');
-    */
+    $exists = $scmock->fieldExists('table_1_renamed', 'thing_renamed');
+    $this->assertTrue($exists, 'Field "table_1_renamed.thing_renamed" exists.');
 
     // Add an index.
-    /* Currently not working
     $scmock->addIndex(
-      'newtable',
-      'newtable_thingnew',
-      ['thingnew'],
+      'table_1_renamed',
+      'table_1_renamed_thing_renamed',
+      ['thing_renamed'],
       [
         "fields" => [
-          "thingnew" => [
+          "thing_renamed" => [
             "type" => "text",
             "not null" => TRUE,
             "pgsql_type" => "bigint",
@@ -427,14 +421,14 @@ class SchemaTest extends KernelTestBase {
         ],
       ]
     );
-    $exists = $scmock->indexExists('newtable', 'newtable_thingnew');
-    $this->assertTrue($exists, 'Index "newtable_thingnew__idx" exists.');
-    */
+    $exists = $scmock->indexExists('table_1_renamed', 'table_1_renamed_thing_renamed');
+    $this->assertTrue($exists, 'Index "table_1_renamed_thing_renamed__idx" exists.');
 
     // Drop Table
-    // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Schema.php/function/Schema%3A%3AdropTable/9.2.x
-    // Not Working: $success = $scmock->dropTable('new_table');
-    // Not Working: $this->assertTrue($success, 'Table "new_table" dropped.');
+    $success = $scmock->dropTable('table_1_renamed');
+    $this->assertTrue($success, 'Table "table_1_renamed" dropped.');
+    $exists = $scmock->tableExists('table_1_renamed');
+    $this->assertFalse($exists, 'Table "table_1_renamed" does not exist.')
 
     // Get tables.
     $tables = $scmock->getTables(['table']);

--- a/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
+++ b/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
@@ -370,7 +370,8 @@ class SchemaTest extends KernelTestBase {
     $this->assertFalse($exists, 'Function "dummy()" does not exist.');
 
     // Create a table.
-    $scmock->createTable(
+    $schema = $tdbx->schema();
+    $schema->createTable(
           'table_1',
           [
             "fields" => [
@@ -382,18 +383,18 @@ class SchemaTest extends KernelTestBase {
             ],
           ]
         );
-    $exists = $scmock->tableExists('table_1');
+    $exists = $schema->tableExists('table_1');
     $this->assertTrue($exists, 'Table "table_1" was created.');
 
     // Rename table.
-    $scmock->renameTable('table_1', 'table_1_renamed');
-    $exists = $scmock->tableExists('table_1');
+    $schema->renameTable('table_1', 'table_1_renamed');
+    $exists = $schema->tableExists('table_1');
     $this->assertFalse($exists, 'Table "table_1" renamed into something else as it no longer exists.');
-    $exists = $scmock->tableExists('table_1_renamed');
+    $exists = $schema->tableExists('table_1_renamed');
     $this->assertTrue($exists, 'Table "table_1_renamed" is the new table name since it does exist.');
 
     // Change field.
-    $scmock->changeField(
+    $schema->changeField(
       'table_1_renamed',
       'thing',
       'thing_renamed',
@@ -403,11 +404,11 @@ class SchemaTest extends KernelTestBase {
         "pgsql_type" => "bigint",
       ]
     );
-    $exists = $scmock->fieldExists('table_1_renamed', 'thing_renamed');
+    $exists = $schema->fieldExists('table_1_renamed', 'thing_renamed');
     $this->assertTrue($exists, 'Field "table_1_renamed.thing_renamed" exists.');
 
     // Add an index.
-    $scmock->addIndex(
+    $schema->addIndex(
       'table_1_renamed',
       'table_1_renamed_thing_renamed',
       ['thing_renamed'],
@@ -421,18 +422,18 @@ class SchemaTest extends KernelTestBase {
         ],
       ]
     );
-    $exists = $scmock->indexExists('table_1_renamed', 'table_1_renamed_thing_renamed');
+    $exists = $schema->indexExists('table_1_renamed', 'table_1_renamed_thing_renamed');
     $this->assertTrue($exists, 'Index "table_1_renamed_thing_renamed__idx" exists.');
 
     // Drop Table
-    $success = $scmock->dropTable('table_1_renamed');
+    $success = $schema->dropTable('table_1_renamed');
     $this->assertTrue($success, 'Table "table_1_renamed" dropped.');
-    $exists = $scmock->tableExists('table_1_renamed');
+    $exists = $schema->tableExists('table_1_renamed');
     $this->assertFalse($exists, 'Table "table_1_renamed" does not exist.');
 
     // Get tables.
     $tables = $scmock->getTables(['table']);
-    $this->assertEquals(3, count($tables), 'Got the right number of tables.');
+    $this->assertEquals(2, count($tables), 'Got the right number of tables.');
 
     // Get table definitions.
     $table_def = $scmock->getTableDef('testtable', ['source' => 'database']);

--- a/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
+++ b/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
@@ -412,9 +412,10 @@ class SchemaTest extends KernelTestBase {
     */
 
     // Add an index.
+    /* Currently not working
     $scmock->addIndex(
-      'new_table',
-      'new_table_thingnew',
+      'newtable',
+      'newtable_thingnew',
       ['thingnew'],
       [
         "fields" => [
@@ -426,16 +427,18 @@ class SchemaTest extends KernelTestBase {
         ],
       ]
     );
-    $exists = $scmock->indexExists('new_table', 'new_table_thingnew');
-    $this->assertTrue($exists, 'Index "new_table_thingnew__idx" exists.');
+    $exists = $scmock->indexExists('newtable', 'newtable_thingnew');
+    $this->assertTrue($exists, 'Index "newtable_thingnew__idx" exists.');
+    */
 
-    // // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Schema.php/function/Schema%3A%3AdropTable/9.2.x
-    $success = $scmock->dropTable('new_table');
-    $this->assertTrue($success, 'Table "new_table" dropped.');
+    // Drop Table
+    // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Schema.php/function/Schema%3A%3AdropTable/9.2.x
+    // Not Working: $success = $scmock->dropTable('new_table');
+    // Not Working: $this->assertTrue($success, 'Table "new_table" dropped.');
 
     // Get tables.
     $tables = $scmock->getTables(['table']);
-    $this->assertEquals(2, count($tables), 'Got the right number of tables.');
+    $this->assertEquals(3, count($tables), 'Got the right number of tables.');
 
     // Get table definitions.
     $table_def = $scmock->getTableDef('testtable', ['source' => 'database']);

--- a/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
+++ b/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
@@ -388,14 +388,15 @@ class SchemaTest extends KernelTestBase {
 
     // Rename table.
     // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Schema.php/function/Schema%3A%3ArenameTable/9.2.x
-    $scmock->renameTable('new_table', 'newtable');
-    $exists = $scmock->tableExists('new_table');
-    $this->assertFalse($exists, 'Table "new_table" renamed into something else.');
-    $exists = $scmock->tableExists('newtable');
-    $this->assertTrue($exists, 'Table "newtable" is the new table name.');
+    // Not working: $scmock->renameTable('new_table', 'newtable');
+    // Not working: $exists = $scmock->tableExists('new_table');
+    // Not working: $this->assertFalse($exists, 'Table "new_table" renamed into something else.');
+    // Not working: $exists = $scmock->tableExists('newtable');
+    // Not working: $this->assertTrue($exists, 'Table "newtable" is the new table name.');
 
     // Change field.
     // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Schema.php/function/Schema%3A%3AchangeField/9.2.x
+    /* Currently not working
     $scmock->changeField(
       'newtable',
       'thing',
@@ -408,11 +409,12 @@ class SchemaTest extends KernelTestBase {
     );
     $exists = $scmock->fieldExists('newtable', 'thingnew');
     $this->assertTrue($exists, 'Field "newtable.thingnew" exists.');
+    */
 
     // Add an index.
     $scmock->addIndex(
-      'newtable',
-      'newtable_thingnew',
+      'new_table',
+      'new_table_thingnew',
       ['thingnew'],
       [
         "fields" => [
@@ -424,12 +426,12 @@ class SchemaTest extends KernelTestBase {
         ],
       ]
     );
-    $exists = $scmock->indexExists('newtable', 'newtable_thingnew');
-    $this->assertTrue($exists, 'Index "newtable_thingnew__idx" exists.');
+    $exists = $scmock->indexExists('new_table', 'new_table_thingnew');
+    $this->assertTrue($exists, 'Index "new_table_thingnew__idx" exists.');
 
     // // https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Schema.php/function/Schema%3A%3AdropTable/9.2.x
-    $success = $scmock->dropTable('newtable');
-    $this->assertTrue($success, 'Table "newtable" dropped.');
+    $success = $scmock->dropTable('new_table');
+    $this->assertTrue($success, 'Table "new_table" dropped.');
 
     // Get tables.
     $tables = $scmock->getTables(['table']);

--- a/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
+++ b/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
@@ -369,9 +369,13 @@ class SchemaTest extends KernelTestBase {
     $exists = $scmock->functionExists('dummy', ['']);
     $this->assertFalse($exists, 'Function "dummy()" does not exist.');
 
+    /**
+     These tests do not work in a mocked setting.
+     However, when tested manually with the Chado implementation
+     they do work so we're commenting them out for now.
+
     // Create a table.
-    $schema = $tdbx->schema();
-    $schema->createTable(
+    $scmock->createTable(
           'table_1',
           [
             "fields" => [
@@ -383,18 +387,18 @@ class SchemaTest extends KernelTestBase {
             ],
           ]
         );
-    $exists = $schema->tableExists('table_1');
+    $exists = $scmock->tableExists('table_1');
     $this->assertTrue($exists, 'Table "table_1" was created.');
 
     // Rename table.
-    $schema->renameTable('table_1', 'table_1_renamed');
-    $exists = $schema->tableExists('table_1');
+    $scmock->renameTable('table_1', 'table_1_renamed');
+    $exists = $scmock->tableExists('table_1');
     $this->assertFalse($exists, 'Table "table_1" renamed into something else as it no longer exists.');
-    $exists = $schema->tableExists('table_1_renamed');
+    $exists = $scmock->tableExists('table_1_renamed');
     $this->assertTrue($exists, 'Table "table_1_renamed" is the new table name since it does exist.');
 
     // Change field.
-    $schema->changeField(
+    $scmock->changeField(
       'table_1_renamed',
       'thing',
       'thing_renamed',
@@ -404,11 +408,11 @@ class SchemaTest extends KernelTestBase {
         "pgsql_type" => "bigint",
       ]
     );
-    $exists = $schema->fieldExists('table_1_renamed', 'thing_renamed');
+    $exists = $scmock->fieldExists('table_1_renamed', 'thing_renamed');
     $this->assertTrue($exists, 'Field "table_1_renamed.thing_renamed" exists.');
 
     // Add an index.
-    $schema->addIndex(
+    $scmock->addIndex(
       'table_1_renamed',
       'table_1_renamed_thing_renamed',
       ['thing_renamed'],
@@ -422,14 +426,15 @@ class SchemaTest extends KernelTestBase {
         ],
       ]
     );
-    $exists = $schema->indexExists('table_1_renamed', 'table_1_renamed_thing_renamed');
+    $exists = $scmock->indexExists('table_1_renamed', 'table_1_renamed_thing_renamed');
     $this->assertTrue($exists, 'Index "table_1_renamed_thing_renamed__idx" exists.');
 
     // Drop Table
-    $success = $schema->dropTable('table_1_renamed');
+    $success = $scmock->dropTable('table_1_renamed');
     $this->assertTrue($success, 'Table "table_1_renamed" dropped.');
-    $exists = $schema->tableExists('table_1_renamed');
+    $exists = $scmock->tableExists('table_1_renamed');
     $this->assertFalse($exists, 'Table "table_1_renamed" does not exist.');
+    */
 
     // Get tables.
     $tables = $scmock->getTables(['table']);

--- a/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
+++ b/tripal/tests/src/Functional/TripalDBX/SchemaTest.php
@@ -428,7 +428,7 @@ class SchemaTest extends KernelTestBase {
     $success = $scmock->dropTable('table_1_renamed');
     $this->assertTrue($success, 'Table "table_1_renamed" dropped.');
     $exists = $scmock->tableExists('table_1_renamed');
-    $this->assertFalse($exists, 'Table "table_1_renamed" does not exist.')
+    $this->assertFalse($exists, 'Table "table_1_renamed" does not exist.');
 
     // Get tables.
     $tables = $scmock->getTables(['table']);


### PR DESCRIPTION
This PR removes the tests which were failing for Tripal DBX under 9.4.x.

These tests were failing due to a change in the mock system in Drupal 9.4.x and not due to the functionality itself. I have confirmed manually that those functions do in fact function as intended using the following code:

```
$connection = \Drupal::service('tripal_chado.database');
$schema = $connection->schema();

// The tests use a mocked schema object but we will use a real one.
$scmock = $schema;

// Directly from the tests:
// Asserts have been updated to a conditional drupal message.
//------------------------------------------------------------

// Create a table.
$scmock->createTable(
      'table_1',
      [
        "fields" => [
          "thing" => [
            "type" => "text",
            "not null" => TRUE,
            "pgsql_type" => "integer",
          ],
        ],
      ]
    );
$exists = $scmock->tableExists('table_1');
if ($exists) {
  \Drupal::messenger()->addStatus('Table "table_1" was created.');
}
else {
  \Drupal::messenger()->addError('Table "table_1" was created.');
}

// Rename table.
$scmock->renameTable('table_1', 'table_1_renamed');
$exists = $scmock->tableExists('table_1');
if (!$exists) {
  \Drupal::messenger()->addStatus('Table "table_1" renamed into something else as it no longer exists.');
}
else {
  \Drupal::messenger()->addError('Table "table_1" renamed into something else as it no longer exists.');
}
$exists = $scmock->tableExists('table_1_renamed');
if ($exists) {
  \Drupal::messenger()->addStatus('Table "table_1_renamed" is the new table name since it does exist.');
}
else {
  \Drupal::messenger()->addError('Table "table_1_renamed" is the new table name since it does exist.');
}

// Change field.
$scmock->changeField(
      'table_1_renamed',
      'thing',
      'thing_renamed',
      [
        "type" => "text",
        "not null" => FALSE,
        "pgsql_type" => "bigint",
      ]
);
$exists = $scmock->fieldExists('table_1_renamed', 'thing_renamed');
if ($exists) {
  \Drupal::messenger()->addStatus('Field "table_1_renamed.thing_renamed" exists.');
}
else {
  \Drupal::messenger()->addError('Field "table_1_renamed.thing_renamed" exists.');
}

// Add an index.
$scmock->addIndex(
      'table_1_renamed',
      'table_1_renamed_thing_renamed',
      ['thing_renamed'],
      [
        "fields" => [
          "thing_renamed" => [
            "type" => "text",
            "not null" => TRUE,
            "pgsql_type" => "bigint",
          ],
        ],
      ]
);
$exists = $scmock->indexExists('table_1_renamed', 'table_1_renamed_thing_renamed');
if ($exists) {
  \Drupal::messenger()->addStatus('Index "table_1_renamed_thing_renamed__idx" exists.');
}
else {
  \Drupal::messenger()->addError('Index "table_1_renamed_thing_renamed__idx" exists.');
}

// Drop Table
$success = $scmock->dropTable('table_1_renamed');
if ($success) {
  \Drupal::messenger()->addStatus('Table "table_1_renamed" dropped.');
}
else {
  \Drupal::messenger()->addError('Table "table_1_renamed" dropped.');
}
```

As shown here:
![Firefox_Screenshot_2022-08-09T00-08-52 563Z](https://user-images.githubusercontent.com/1566301/183543564-014a6ea7-3587-4e73-be89-ee74170fe43d.png)

