### PR TITLE
BUG Fix #312: pass schema name instead of connection object.

### DIFF
--- a/tripal_chado/tests/src/Functional/Task/ChadoPreparerTest.php
+++ b/tripal_chado/tests/src/Functional/Task/ChadoPreparerTest.php
@@ -46,7 +46,7 @@ class ChadoPreparerTest extends ChadoTestBrowserBase {
     $this->assertTrue($success, 'Task performed.');
 
     // Check that the prepare step created what we expected it to.
-    $this->runPrepareStepAssertions($test_chado);
+    $this->runPrepareStepAssertions($test_chado->getSchemaName());
   }
 
   /**
@@ -58,13 +58,15 @@ class ChadoPreparerTest extends ChadoTestBrowserBase {
    */
   public function testPrepareTestChadoSimulation() {
     $prepared_chado = $this->getTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
-    $this->runPrepareStepAssertions($prepared_chado);
+    $this->runPrepareStepAssertions($prepared_chado->getSchemaName());
   }
 
   /**
    * Helper Method: Check that the prepare step created what we expected it to.
    */
-  protected function runPrepareStepAssertions($chado2check) {
+  protected function runPrepareStepAssertions($chadoSchema2check) {
+    $chado2check = \Drupal::service('tripal_chado.database');
+    $chado2check->setSchemaName($chadoSchema2check);
     $schema2check = $chado2check->schema();
 
     // 1: CREATE CHADO CUSTOM TABLES.


### PR DESCRIPTION
See Issue #312 

tl;dr;

We were seeing a LogicException regarding the database connection when prepare tests failed:

> PHPUnit\Framework\Exception: PHP Fatal error: Uncaught LogicException: The database connection is not serializable.

It turns out this was only happening if a test failed within the helper function runPrepareStepAssertions(). It was due to passing a connection object as a parameter to the helper function during testing 🙈 Switching to instead pass the schema name and then re-setup the connection fixed the bug.
