### PR TITLE
Tripal content types: full support for TripalTerms

### DIFF
--- a/tripal/config/install/tripal.settings.yml
+++ b/tripal/config/install/tripal.settings.yml
@@ -1,5 +1,10 @@
 langcode: 'en'
 
+tripal_entity_type:
+  # The current highest Tripal Content Type ID
+  # This should only by set in the TripalEntityType::save() method.
+  max_id: 0
+
 files:
   # Maximum size for file uploads (defaults to 1 GB)
   max_size: 1000000000

--- a/tripal/config/schema/tripal.settings.schema.yml
+++ b/tripal/config/schema/tripal.settings.schema.yml
@@ -2,6 +2,11 @@ tripal.settings:
   type: config_object
   label: Tripal Settings
   mapping:
+    tripal_entity_type:
+      type: config_object
+      mapping:
+        max_id:
+          type: integer
     files:
       type: config_object
       mapping:

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -208,11 +208,13 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    public function save() {
 
      // First we want to set an id for this content type.
-     $config = \Drupal::service('config.factory')->getEditable('tripal.settings');
-     $max_id = $config->get('tripal_entity_type.max_id');
-     $this->id = $max_id + 1;
-     $this->name = 'bio_data_' . $this->id;
-     $config->set('tripal_entity_type.max_id', $this->id)->save();
+     if ($this->isNew()) {
+       $config = \Drupal::service('config.factory')->getEditable('tripal.settings');
+       $max_id = $config->get('tripal_entity_type.max_id');
+       $this->id = $max_id + 1;
+       $this->name = 'bio_data_' . $this->id;
+       $config->set('tripal_entity_type.max_id', $this->id)->save();
+     }
 
      // Set defaults for anything not already set.
      $this->setDefaults();
@@ -354,7 +356,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    * {@inheritdoc}
    */
   public function setTermAccession($termAccession) {
-    $this->termIdSpace = $termAccession;
+    $this->termAccession = $termAccession;
     return $this;
   }
 

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -161,21 +161,8 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    *      -
    * @return TripalEntityType
    *    An TripalEntityType with the values passed in set appropriately.
-   *
+   */
   public static function create(array $values = []) {
-
-    // Set the id and name of the content type. This follows a very specific
-    // pattern and thus should not be set in the $values array.
-    // Get the next bio_data_x index number.
-    $cid = 'chado_bio_data_index';
-    $cached_val = \Drupal::cache()->get($cid, 0);
-    if (is_object($cached_val)) {
-      $cached_val = $cached_val->data;
-    }
-    $next_index = $cached_val + 1;
-    $bundle = 'bio_data_' . $next_index;
-    $values['id'] = $next_index;
-    $values['name'] = $bundle;
 
     // Check if a TripalTerm object was passed in.
     // If yes, extract the ID Space and Accession for saving.
@@ -232,7 +219,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     // for storage and retrieve the Term object later if requested via getTerm().
     return parent::create($values);
   }
-  */
+
 
   /**
    * Saves the new TripalEntityType permanently.
@@ -245,7 +232,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    *
    * @return int
    *   Either SAVED_NEW or SAVED_UPDATED, depending on the operation performed.
-   *
+   */
    public function save() {
 
      // Check that the TripalTerm exists with the ID Space and Accession
@@ -253,10 +240,16 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
 
      // If not, then create the TripalTerm, TripalIDSpace and TripalVocabulary.
 
-     // Finally save the rest of the entity using the parent implementation.
-     return parent::save();
+     // Save the rest of the entity using the parent implementation.
+     // This is when the id is assigned.
+     $return_status = parent::save();
+
+     // Next, we want to set the name based on the id.
+     // Specifically, we expect bio_data_[id] to be the name of the Tripal Content Type.
+     // $this->name = 'bio_data_' . $this->id;
+
+     return $return_status;
    }
-   */
 
   // --------------------------------------------------------------------------
   //                          MAIN SETTER / GETTERS

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -366,7 +366,12 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
   public function getTerm() {
     $manager = \Drupal::service('tripal.collection_plugin_manager.idspace');
     $idspace = $manager->loadCollection($this->termIdSpace);
-    return $idspace->getTerm($this->termAccession);
+    if (is_object($idspace)) {
+      return $idspace->getTerm($this->termAccession);
+    }
+    else {
+      return NULL;
+    }
   }
 
   /**

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -137,6 +137,68 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
   protected $ajax_field;
 
   // --------------------------------------------------------------------------
+  //                             CREATE + SAVE
+  //
+  // Tripal Entity Types are created using the Drupal Entity API.
+  // To create new type, you will use the static create function we extended
+  // below to pass in the info for the new type and then call the save method on
+  // the created object to permanently save it to your site.
+  //
+  //    $new_entityType = TripalEntityType::create($details);
+  //    if (is_object($entityType)) {
+  //      $new_entityType->save();
+  //    }
+  // --------------------------------------------------------------------------
+
+  /**
+   * Contructs a new TripalEntityType object without permanently saving it.
+   *
+   * Extends EntityBase::create() with support for TripalTerm as a value.
+   *
+   * @param array $values
+   *    An array of values to set, keyed by property name. Supported keys are:
+   *      -
+   * @return TripalEntityType
+   *    An TripalEntityType with the values passed in set appropriately.
+   */
+  public static function create(array $values = []) {
+
+    // Check if a TripalTerm object was passed in.
+    // If yes, extract the ID Space and Accession for saving.
+
+    // Ensure that required values are supplied.
+
+    // Let the parent implementation finish creating the object.
+    // NOTE: We do things in this order because a configuration entity cannot
+    // save an object to it's storage. Thus we need to extract the term strings
+    // for storage and retrieve the Term object later if requested via getTerm().
+    parent::create($values);
+  }
+
+  /**
+   * Saves the new TripalEntityType permanently.
+   *
+   * Extends ConfigEntityBase::save() with support for creating the associated
+   * TripalTerm if it doesn't already exist.
+   *
+   * When saving existing entities, the entity is assumed to be complete,
+   * partial updates of entities are not supported.
+   *
+   * @return int
+   *   Either SAVED_NEW or SAVED_UPDATED, depending on the operation performed.
+   */
+   public function save() {
+
+     // Check that the TripalTerm exists with the ID Space and Accession
+     // added to this type when it was created.
+
+     // If not, then create the TripalTerm, TripalIDSpace and TripalVocabulary.
+
+     // Finally save the rest of the entity using the parent implementation.
+     return parent::save();
+   }
+
+  // --------------------------------------------------------------------------
   //                          MAIN SETTER / GETTERS
   //
   // The following methods allow the main properties of the Tripal Entity Type

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -161,7 +161,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    *      -
    * @return TripalEntityType
    *    An TripalEntityType with the values passed in set appropriately.
-   */
+   *
   public static function create(array $values = []) {
 
     // Set the id and name of the content type. This follows a very specific
@@ -185,6 +185,12 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
         unset($values['term']);
         $values['termIdSpace'] = $term->getIdSpace();
         $values['termAccession'] = $term->getAccession();
+
+        // Since we have a term object, we can use the definition to set the
+        // help text if it's not already set.
+        if (!array_key_exists('help_text', $values)) {
+          $values['help_text'] = $term->getDefinition();
+        }
       }
       else {
         $class_name_passed_in = get_class($values['term']);
@@ -219,21 +225,6 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
         throw new \Exception("The $key is required when creating a TripalEntityType.");
       }
     }
-    // Check that the title format is provided and contains at least one token.
-    if (array_key_exists('title_format', $values)) {
-      // @todo
-    }
-    else {
-      throw new \Exception("You must provide a title format when creating a TripalEntityType.");
-    }
-    // Check that the URL format is provided, contains at least one token
-    // and is a valid URL.
-    if (array_key_exists('url_format', $values)) {
-      // @todo
-    }
-    else {
-      throw new \Exception("You must provide a URL format when creating a TripalEntityType.");
-    }
 
     // Let the parent implementation finish creating the object.
     // NOTE: We do things in this order because a configuration entity cannot
@@ -241,6 +232,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
     // for storage and retrieve the Term object later if requested via getTerm().
     return parent::create($values);
   }
+  */
 
   /**
    * Saves the new TripalEntityType permanently.
@@ -253,7 +245,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    *
    * @return int
    *   Either SAVED_NEW or SAVED_UPDATED, depending on the operation performed.
-   */
+   *
    public function save() {
 
      // Check that the TripalTerm exists with the ID Space and Accession
@@ -264,6 +256,7 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
      // Finally save the rest of the entity using the parent implementation.
      return parent::save();
    }
+   */
 
   // --------------------------------------------------------------------------
   //                          MAIN SETTER / GETTERS

--- a/tripal/src/Entity/TripalEntityType.php
+++ b/tripal/src/Entity/TripalEntityType.php
@@ -235,6 +235,13 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
    */
    public function save() {
 
+     // First we want to set an id for this content type.
+     $config = \Drupal::service('config.factory')->getEditable('tripal.settings');
+     $max_id = $config->get('tripal_entity_type.max_id');
+     $this->id = $max_id + 1;
+     $this->name = 'bio_data_' . $this->id;
+     $config->set('tripal_entity_type.max_id', $this->id)->save();
+
      // Check that the TripalTerm exists with the ID Space and Accession
      // added to this type when it was created.
 
@@ -243,10 +250,6 @@ class TripalEntityType extends ConfigEntityBundleBase implements TripalEntityTyp
      // Save the rest of the entity using the parent implementation.
      // This is when the id is assigned.
      $return_status = parent::save();
-
-     // Next, we want to set the name based on the id.
-     // Specifically, we expect bio_data_[id] to be the name of the Tripal Content Type.
-     // $this->name = 'bio_data_' . $this->id;
 
      return $return_status;
    }

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -21,6 +21,8 @@ class TripalEntityTypeForm extends EntityForm {
     $form = parent::form($form, $form_state);
 
     $tripal_entity_type = $this->entity;
+    $tripal_entity_type->setDefaults();
+
     $form['label'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Label'),
@@ -33,25 +35,9 @@ class TripalEntityTypeForm extends EntityForm {
 
     // Determine the machine name for the content type.
     if ($tripal_entity_type->isNew()) {
-
-      $db = \Drupal::database();
-      $highest_name = $db->select('config', 'c')
-        ->fields('c', ['name'])
-        ->condition('c.name', 'tripal.bio_data.', '~')
-        ->orderBy('c.name', 'DESC')
-        ->execute()
-        ->fetchField();
-      if ($highest_name) {
-        $max_index = str_replace(
-          'tripal.bio_data.bio_data_',
-          '',
-          $highest_name
-        );
-        $default_id = $max_index + 1;
-      }
-      else {
-        $default_id = 1;
-      }
+      $config = \Drupal::config('tripal.settings');
+      $max_index = $config->get('tripal_entity_type.max_id');
+      $default_id = $max_index + 1;
     }
     else {
       $default_id = $tripal_entity_type->getID();

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -32,7 +32,6 @@ class TripalEntityTypeForm extends EntityForm {
       '#required' => TRUE,
     ];
 
-
     // Determine the machine name for the content type.
     if ($tripal_entity_type->isNew()) {
       $config = \Drupal::config('tripal.settings');
@@ -58,8 +57,9 @@ class TripalEntityTypeForm extends EntityForm {
 
     // We need to choose a term if this is a new content type.
     // The term cannot be changed later!
-    /*
     if ($tripal_entity_type->isNew()) {
+
+      /*
       $description = t('The Tripal controlled vocabulary term (cv) term which characterizes this content type. For example, to create a content type for storing "genes", use the "gene" term from the Sequence Ontology (SO). <strong>The Tripal CV Term must already exist; you can <a href="@termUrl">add a Tripal CV Term here</a>.</strong>',
         ['@termUrl' => Url::fromRoute('entity.tripal_vocab.collection')->toString()]);
       $form['term_id'] = [
@@ -69,14 +69,15 @@ class TripalEntityTypeForm extends EntityForm {
         '#target_type' => 'tripal_term',
         '#required' => TRUE,
       ];
+      */
     }
     else {
       $term = $tripal_entity_type->getTerm();
-      $vocab = $term->getVocab();
+      $vocab = $term->getVocabularyObject();
       // Save the term for later.
       $form['term_id'] = [
         '#type' => 'hidden',
-        '#value' => $term->getId(),
+        '#value' => $term->getInternalId(),
       ];
       // Describe the term to the user but do not allow them to change it.
       $form['term'] = [
@@ -84,22 +85,21 @@ class TripalEntityTypeForm extends EntityForm {
         '#caption' => 'Controlled Vocabulary Term',
         '#rows' => [
           [
-            ['header' => TRUE, 'data' => 'Vocabulary'],
+            'Vocabulary',
             $vocab->getLabel()
           ],
           [
-            ['header' => TRUE, 'data' => 'Name'],
+            'Name',
             $term->getName()
           ],
           [
-            ['header' => TRUE, 'data' => 'Accession'],
-            $term->getAccession()
+            'Accession',
+            $term->getTermId()
           ],
         ],
         '#weight' => -8,
       ];
     }
-    */
 
     $description = "A grouping category for this Tripal Content type. It should be the same as other Tripal Content types and can be used to group similar biological data types to make them easier to find.";
     $form['category'] = [

--- a/tripal/src/Form/TripalEntityTypeForm.php
+++ b/tripal/src/Form/TripalEntityTypeForm.php
@@ -51,11 +51,19 @@ class TripalEntityTypeForm extends EntityForm {
     // NOTE: we go this route because only showin the field on the add page
     // causes a validation error.
     else {
-      $term = $tripal_entity_type->getTerm();
-      $vocab = $term->getVocabularyObject();
+      $vocab_label = $term_name = $term_accession = '';
 
-      $term_autocomplete_default = $term->getName() . ' (' . $term->getTermId() . ')';
-      $disabled = TRUE;
+      $term = $tripal_entity_type->getTerm();
+      if ($term) {
+        $vocab = $term->getVocabularyObject();
+
+        $vocab_label = $vocab->getLabel();
+        $term_name = $term->getName();
+        $term_accession = $term->getTermId();
+
+        $term_autocomplete_default = $term->getName() . ' (' . $term->getTermId() . ')';
+        $disabled = TRUE;
+      }
 
       // We also want to add an element at the top that fully describes the term.
       // So lets do that here and use weight to put it at the top.
@@ -65,15 +73,15 @@ class TripalEntityTypeForm extends EntityForm {
         '#rows' => [
           [
             'Vocabulary',
-            $vocab->getLabel()
+            $vocab_label
           ],
           [
             'Name',
-            $term->getName()
+            $term_name
           ],
           [
             'Accession',
-            $term->getTermId()
+            $term_accession
           ],
         ],
         '#weight' => -8,

--- a/tripal/src/ListBuilders/TripalEntityTypeListBuilder.php
+++ b/tripal/src/ListBuilders/TripalEntityTypeListBuilder.php
@@ -43,19 +43,10 @@ class TripalEntityTypeListBuilder extends ConfigEntityListBuilder {
 
     // Add in the term with link.
     $data['term'] = '';
-    /*
     $term = $entity->getTerm();
     if ($term) {
-      $idspace = $term->getIDSpace();
-      if ($idspace) {
-        $term_display = $term->getName() . ' (' . $idspace->getIDSpace() . ':' . $term->getAccession() . ')';
-        $data['term'] = Link::fromTextAndUrl(
-          $term_display,
-          $term->toUrl('canonical', ['tripal_term' => $term->id()])
-        )->toString();
-      }
+      $data['term'] = $term->getName() . ' (' . $term->getTermId() . ')';
     }
-    */
 
     // Add in classes for better themeing and testing.
     $rowData = [];

--- a/tripal/tests/src/Functional/Entity/EntityAccessTest.php
+++ b/tripal/tests/src/Functional/Entity/EntityAccessTest.php
@@ -24,42 +24,43 @@ class EntityAccessTest extends BrowserTestBase {
    */
   public function testTripalAccessOwnContentCheck() {
 
-		$account_other = $this->drupalCreateUser([]);
-		$owner = $account_owner = $this->drupalCreateUser([]);
+    $account_other = $this->drupalCreateUser([]);
+    $owner = $account_owner = $this->drupalCreateUser([]);
 
 
-		$access_check_obj = new \Drupal\tripal\Access\TripalAccessOwnContentCheck();
+    $access_check_obj = new \Drupal\tripal\Access\TripalAccessOwnContentCheck();
 
-		$result = $access_check_obj->access($owner, $account_other);
-		$this->assertInstanceOf(AccessResultForbidden::class, $result, "A user other then the owner should not be allowed access.");
+    $result = $access_check_obj->access($owner, $account_other);
+    $this->assertInstanceOf(AccessResultForbidden::class, $result, "A user other then the owner should not be allowed access.");
 
-		$result = $access_check_obj->access($owner, $account_owner);
-		$this->assertInstanceOf(AccessResultAllowed::class, $result, "The owner should be allowed access.");
-	}
+    $result = $access_check_obj->access($owner, $account_owner);
+    $this->assertInstanceOf(AccessResultAllowed::class, $result, "The owner should be allowed access.");
+  }
 
-	/**
+  /**
    * Test TripalEntityAccessControlHandler
    */
   public function testTripalEntityAccessControlHandler() {
 
-		// One user per permission to check.
-		$user_unpriviledged = $this->drupalCreateUser([]);
-		$user_view = $this->drupalCreateUser(['view tripal content entities']);
-		$user_edit = $this->drupalCreateUser(['edit tripal content entities']);
-		$user_delete = $this->drupalCreateUser(['delete tripal content entities']);
-		$user_add = $this->drupalCreateUser(['add tripal content entities']);
+    // One user per permission to check.
+    $user_unpriviledged = $this->drupalCreateUser([]);
+    $user_view = $this->drupalCreateUser(['view tripal content entities']);
+    $user_edit = $this->drupalCreateUser(['edit tripal content entities']);
+    $user_delete = $this->drupalCreateUser(['delete tripal content entities']);
+    $user_add = $this->drupalCreateUser(['add tripal content entities']);
 
-		// Create a Content Type + Entity for this test.
+    // Create a Content Type + Entity for this test.
     // -- Content Type.
     $values = [];
-    $values['id'] = random_int(1,500);
-    $values['name'] = 'bio_data_' . $values['id'];
     $values['label'] = 'Freddyopolis-' . uniqid();
+    $values['termIdSpace'] = 'FRED';
+    $values['termAccession'] = '1g2h3j4k5';
+    $values['help_text'] = 'This is just random text to meet the requirement of this field.';
     $values['category'] = 'Testing';
     $content_type_obj = \Drupal\tripal\Entity\TripalEntityType::create($values);
     $this->assertIsObject($content_type_obj, "Unable to create a test content type.");
     $content_type_obj->save();
-    $content_type = $values['name'];
+    $content_type = $content_type_obj->id();
     // -- Content Entity.
     $values = [];
     $values['title'] = 'Mini Fredicity ' . uniqid();
@@ -69,52 +70,52 @@ class EntityAccessTest extends BrowserTestBase {
     $entity->save();
     $entity_id = $entity->id();
 
-		// Get the access check object.
-		$entity_type_interface = \Drupal::entityTypeManager()->getDefinition('tripal_entity');
-		$access_check_obj = new \Drupal\Tests\tripal\Functional\Entity\Subclass\TripalEntityAccessControlHandlerFake($entity_type_interface);
+    // Get the access check object.
+    $entity_type_interface = \Drupal::entityTypeManager()->getDefinition('tripal_entity');
+    $access_check_obj = new \Drupal\Tests\tripal\Functional\Entity\Subclass\TripalEntityAccessControlHandlerFake($entity_type_interface);
 
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'view', $user_unpriviledged);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "An unpriviledged user should NOT be allowed to VIEW the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'view', $user_view);
-		$this->assertInstanceOf(AccessResultAllowed::class, $result, "A user with view permission should be allowed to VIEW the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'view', $user_edit);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with edit permission should NOT be allowed to VIEW the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'view', $user_delete);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with delete permission should NOT be allowed to VIEW the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'view', $user_add);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with add permission should NOT be allowed to VIEW the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'view', $user_unpriviledged);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "An unpriviledged user should NOT be allowed to VIEW the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'view', $user_view);
+    $this->assertInstanceOf(AccessResultAllowed::class, $result, "A user with view permission should be allowed to VIEW the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'view', $user_edit);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with edit permission should NOT be allowed to VIEW the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'view', $user_delete);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with delete permission should NOT be allowed to VIEW the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'view', $user_add);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with add permission should NOT be allowed to VIEW the entity.");
 
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'update', $user_unpriviledged);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "An unpriviledged user should NOT be allowed to UPDATE the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'update', $user_view);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with view permission should NOT be allowed to UPDATE the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'update', $user_edit);
-		$this->assertInstanceOf(AccessResultAllowed::class, $result, "A user with edit permission should be allowed to UPDATE the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'update', $user_delete);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with delete permission should NOT be allowed to UPDATE the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'update', $user_add);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with add permission should NOT be allowed to UPDATE the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'update', $user_unpriviledged);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "An unpriviledged user should NOT be allowed to UPDATE the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'update', $user_view);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with view permission should NOT be allowed to UPDATE the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'update', $user_edit);
+    $this->assertInstanceOf(AccessResultAllowed::class, $result, "A user with edit permission should be allowed to UPDATE the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'update', $user_delete);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with delete permission should NOT be allowed to UPDATE the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'update', $user_add);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with add permission should NOT be allowed to UPDATE the entity.");
 
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'delete', $user_unpriviledged);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "An unpriviledged user should NOT be allowed to DELETE the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'delete', $user_view);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with view permission should be allowed to DELETE the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'delete', $user_edit);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with edit permission should NOT be allowed to DELETE the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'delete', $user_delete);
-		$this->assertInstanceOf(AccessResultAllowed::class, $result, "A user with delete permission should be allowed to DELETE the entity.");
-		$result = $access_check_obj->returnProtectedCheckAccess($entity, 'delete', $user_add);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with add permission should NOT be allowed to DELETE the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'delete', $user_unpriviledged);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "An unpriviledged user should NOT be allowed to DELETE the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'delete', $user_view);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with view permission should be allowed to DELETE the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'delete', $user_edit);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with edit permission should NOT be allowed to DELETE the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'delete', $user_delete);
+    $this->assertInstanceOf(AccessResultAllowed::class, $result, "A user with delete permission should be allowed to DELETE the entity.");
+    $result = $access_check_obj->returnProtectedCheckAccess($entity, 'delete', $user_add);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with add permission should NOT be allowed to DELETE the entity.");
 
-		$result = $access_check_obj->returnProtectedCheckCreateAccess($user_unpriviledged);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "An unpriviledged user should NOT be allowed to CREATE the entity.");
-		$result = $access_check_obj->returnProtectedCheckCreateAccess($user_view);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with view permission should NOT be allowed to CREATE the entity.");
-		$result = $access_check_obj->returnProtectedCheckCreateAccess($user_edit);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with edit permission should NOT be allowed to CREATE the entity.");
-		$result = $access_check_obj->returnProtectedCheckCreateAccess($user_delete);
-		$this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with delete permission should NOT be allowed to CREATE the entity.");
-		$result = $access_check_obj->returnProtectedCheckCreateAccess($user_add);
-		$this->assertInstanceOf(AccessResultAllowed::class, $result, "A user with add permission should be allowed to CREATE the entity.");
-	}
+    $result = $access_check_obj->returnProtectedCheckCreateAccess($user_unpriviledged);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "An unpriviledged user should NOT be allowed to CREATE the entity.");
+    $result = $access_check_obj->returnProtectedCheckCreateAccess($user_view);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with view permission should NOT be allowed to CREATE the entity.");
+    $result = $access_check_obj->returnProtectedCheckCreateAccess($user_edit);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with edit permission should NOT be allowed to CREATE the entity.");
+    $result = $access_check_obj->returnProtectedCheckCreateAccess($user_delete);
+    $this->assertInstanceOf(AccessResultNeutral::class, $result, "A user with delete permission should NOT be allowed to CREATE the entity.");
+    $result = $access_check_obj->returnProtectedCheckCreateAccess($user_add);
+    $this->assertInstanceOf(AccessResultAllowed::class, $result, "A user with add permission should be allowed to CREATE the entity.");
+  }
 }

--- a/tripal/tests/src/Functional/Entity/TripalContentTest.php
+++ b/tripal/tests/src/Functional/Entity/TripalContentTest.php
@@ -20,19 +20,25 @@ class TripalContentTest extends TripalTestBrowserBase {
 
     // Setting the default values:
     $random = $this->getRandomGenerator();
-    // Sets a random id + associated machine name.
-    $values['id'] = random_int(1,500);
-    $values['name'] = 'bio_data_' . $values['id'];
     // Provides a title with ~8 latin capitalized words.
     $values['label'] = $random->sentences(8,TRUE);
     // Provides a category with ~3 latin capitalized words.
     $values['category'] = $random->sentences(3,TRUE);
+    // Provides a title with ~8 latin capitalized words.
+    $values['help_text'] = $random->sentences(25);
+    // Provides a title with ~8 latin capitalized words.
+    $values['title_format'] = $random->sentences(8,TRUE);
+    // Provides a category with ~3 latin capitalized words separated by '/'.
+    $values['url_format'] = str_replace(' ', '/', $random->sentences(3,TRUE));
 
     // Create a mock term to provide to the entity.
-    $term_name = $random->sentences(3,TRUE);
+    $term_idspace = $random->sentences(3,TRUE);
+    $term_accession = $random->sentences(3,TRUE);
     $term = $this->createMock('\Drupal\tripal\TripalVocabTerms\TripalTerm');
     $term->expects($this->any())
-      ->method('getName')->will($this->returnValue($term_name));
+      ->method('getIdSpace')->will($this->returnValue($term_idspace));
+    $term->expects($this->any())
+      ->method('getAccession')->will($this->returnValue($term_accession));
     $values['term'] = $term;
 
     // Actually creating the type.
@@ -41,8 +47,8 @@ class TripalContentTest extends TripalTestBrowserBase {
     $entity_type_obj->save();
 
     // A quick double check before returning it.
-    $entity_type = $entity_type_obj->getName();
-    $this->assertEquals($values['name'], $entity_type, "Unable to retrieve machine name from the newly created entity type.");
+    $entity_type_label = $entity_type_obj->getLabel();
+    $this->assertEquals($values['label'], $entity_type_label, "Unable to retrieve label from the newly created entity type.");
   }
 
   /**

--- a/tripal/tests/src/Functional/TripalRoutePermissionsTest.php
+++ b/tripal/tests/src/Functional/TripalRoutePermissionsTest.php
@@ -235,14 +235,15 @@ class TripalRoutePermissionsTest extends BrowserTestBase {
     // Create a Content Type + Entity for this test.
     // -- Content Type.
     $values = [];
-    $values['id'] = random_int(1,500);
-    $values['name'] = 'bio_data_' . $values['id'];
     $values['label'] = 'Freddyopolis-' . uniqid();
+    $values['termIdSpace'] = 'FRED';
+    $values['termAccession'] = '1g2h3j4k5';
+    $values['help_text'] = 'This is just random text to meet the requirement of this field.';
     $values['category'] = 'Testing';
     $content_type_obj = \Drupal\tripal\Entity\TripalEntityType::create($values);
     $this->assertIsObject($content_type_obj, "Unable to create a test content type.");
     $content_type_obj->save();
-    $content_type = $values['name'];
+    $content_type = $content_type_obj->id();
     // -- Content Entity.
     $values = [];
     $values['title'] = 'Mini Fredicity ' . uniqid();

--- a/tripal/tests/src/Functional/TripalTestBrowserBase.php
+++ b/tripal/tests/src/Functional/TripalTestBrowserBase.php
@@ -229,8 +229,6 @@ abstract class TripalTestBrowserBase extends BrowserTestBase {
 
     // Setting the default values:
     $random = $this->getRandomGenerator();
-    $values['id'] = $values['id'] ?? random_int(1,500);
-    $values['name'] = $values['name'] ?? 'bio_data_' . $values['id'];
     // Provides a title with ~3 latin capitalized words.
     $values['label'] = $values['label'] ?? $random->sentences(3,TRUE);
     // Provides a random non-unique 4 character string.
@@ -251,8 +249,7 @@ abstract class TripalTestBrowserBase extends BrowserTestBase {
     $entity_type_obj->save();
 
     // A quick double check before returning it.
-    $entity_type = $entity_type_obj->getName();
-    $this->assertEquals($values['name'], $entity_type, "Unable to retrieve machine name from the newly created entity type.");
+    $this->assertEquals($values['label'], $entity_type_obj->getLabel(), "Unable to retrieve label from the newly created entity type.");
 
     return $entity_type_obj;
   }

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -1082,6 +1082,7 @@ class ChadoPreparer extends ChadoTaskBase {
         $entityType->save();
         $this->logger->notice(t('Content type, "@type", created..',
             ['@type' => $details['label']]));
+        $bundle = $entityType->getName();
         \Drupal::cache()->set($cid, $next_index);
       }
       else {

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -1044,16 +1044,6 @@ class ChadoPreparer extends ChadoTaskBase {
     $entityType = NULL;
     $bundle = '';
 
-    $cid = 'chado_bio_data_index';
-    $cached_val = \Drupal::cache()->get($cid, 0);
-    if (is_object($cached_val)) {
-      $cached_val = $cached_val->data;
-    }
-    $next_index = $cached_val + 1;
-    $bundle = 'bio_data_' . $next_index;
-    $details['id'] = $next_index;
-    $details['name'] = $bundle;
-
     $term = $details['term'];
     if (!array_key_exists('term', $details) or !$details['term']) {
       $this->logger->error(t('Creation of content type, "@type", failed. No term provided.',
@@ -1083,7 +1073,6 @@ class ChadoPreparer extends ChadoTaskBase {
         $this->logger->notice(t('Content type, "@type", created..',
             ['@type' => $details['label']]));
         $bundle = $entityType->getName();
-        \Drupal::cache()->set($cid, $next_index);
       }
       else {
         $this->logger->error(t('Creation of content type, "@type", failed. The provided details were: ',

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -1044,6 +1044,16 @@ class ChadoPreparer extends ChadoTaskBase {
     $entityType = NULL;
     $bundle = '';
 
+    $cid = 'chado_bio_data_index';
+    $cached_val = \Drupal::cache()->get($cid, 0);
+    if (is_object($cached_val)) {
+      $cached_val = $cached_val->data;
+    }
+    $next_index = $cached_val + 1;
+    $bundle = 'bio_data_' . $next_index;
+    $details['id'] = $next_index;
+    $details['name'] = $bundle;
+
     $term = $details['term'];
     if (!array_key_exists('term', $details) or !$details['term']) {
       $this->logger->error(t('Creation of content type, "@type", failed. No term provided.',

--- a/tripal_chado/src/Task/ChadoPreparer.php
+++ b/tripal_chado/src/Task/ChadoPreparer.php
@@ -1067,17 +1067,6 @@ class ChadoPreparer extends ChadoTaskBase {
       $entityType = $entityTypes[$bundle];
     }
     else {
-      // Get the next bio_data_x index number.
-      $cid = 'chado_bio_data_index';
-      $cached_val = \Drupal::cache()->get($cid, 0);
-      if (is_object($cached_val)) {
-        $cached_val = $cached_val->data;
-      }
-      $next_index = $cached_val + 1;
-      $bundle = 'bio_data_' . $next_index;
-      $details['id'] = $next_index;
-      $details['name'] = $bundle;
-
       $entityType = TripalEntityType::create($details);
       if (is_object($entityType)) {
         $entityType->save();


### PR DESCRIPTION
This PR adds full support for Tripal Terms to Tripal Content Types. This was started by @spficklin with #244 in the Chado Prepare and with previous implementation of TripalTerms.

#### How to Test
1. Build a new version of the Tripal Docker. This is needed to ensure the prepare step is run fresh on a clean site. Simply running prepare on an existing site may not be sufficient as the content types already exist.

```
git clone https://github.com/tripal/t4d8.git t4d8-256
cd t4d8-256
git checkout tv4g1-issue256-tripalContentType-termsAttached
docker build --tag=tripalproject/tripaldocker:t4d8-256 --build-arg drupalversion='9.4.x-dev' ./
```

The image should build without error. This shows that prepare can still be run + create content types without throwing exceptions.

2. Now create a container to do your testing in.

```
docker run --publish=9000:80 --name=t4d8-256 -tid --volume=`pwd`:/var/www/drupal9/web/modules/contrib/tripal tripalproject/tripaldocker:t4d8-256
docker exec t4d8-256 service postgresql restart
```

All further steps take place in this container through the web browser: localhost

3. Go to the Tripal Content Types listing (Admin > Tripal > Page Structure) and check that all content types are created and that the term column is filled out. This shows the prepare attached terms properly and that the list builder is able to retrieve them.
<img width="1521" alt="Screen Shot 2022-12-26 at 1 03 46 PM" src="https://user-images.githubusercontent.com/1566301/209577096-714b7bb7-a684-49a8-82e5-07aaa0581403.png">

4. Edit any content type and check that the term is fully described at the top of the page and the autocomplete is filled out and disabled. Save the content type again to make sure it doesn't change the term or throw and error on update.
<img width="1521" alt="Screen Shot 2022-12-26 at 1 04 11 PM" src="https://user-images.githubusercontent.com/1566301/209577107-0be0788e-50dc-4823-961f-645e3794079d.png">

5. Now create a new content type by clicking "Add Tripal Content Type" at the top of the Tripal Page Structure page. Fill in all the required fields. Confirm the controlled vocabulary term autocomplete pulls up values. Try the following and ensure you get validation errors:

- Change the ID Space to something that doesn't exist but still match the format (format is `NAME (ID SPACE:ACCESSION)`)
- Change the accession to something that doesn't exist but still match the format.
- Put randomness that does not match the format.
- Enter a term that is already attached to another content type (example: `gene (SO:0000704)`).

<img width="1521" alt="Screen Shot 2022-12-26 at 1 04 11 PM" src="https://user-images.githubusercontent.com/1566301/209577392-0c23d4a3-80ad-4a4e-82b3-b9dd59d46143.png">

6. Finally fill out the form in the above step correctly and click save. Check the new content type is in the list with the correct term associated with it.

<img width="1483" alt="Screen Shot 2022-12-26 at 1 12 04 PM" src="https://user-images.githubusercontent.com/1566301/209577547-1b648a2d-fba7-4dc9-bccc-80a14d1b885c.png">


#### PR Summary of Changes
✅ Pass term object to create and it saves IDSpace and Accession + sets help text based on term definition if not already set
✅ The content type ID/Name (i.e. bio_data\d+) is not automatically created when the content type is saved
✅ If not set already, the category, hide_empty_field and ajax_field are set with sensible details on save.
✅ Label, help text, term IDSpace + Accession are now checked/required on save (exception thrown).
✅ There is a new setTerm() method to allow you to set the term details with a term object rather then separately.
✅ Upgraded edit/create tripalentitytype form to show the attached term if set.
✅ Updated some tests which didn't meet the new requirements for content types.
✅ Edit/create form now has the same term autocomplete that field settings do. It is set via form state on create and via the term on update. It's disabled on update.
✅ Added to the validate of the edit/create for. It now validates the following:

- All required values were supplied (validated by Drupal automatically.
- No entity with the same label already exists
- The term was entered in the correct format: NAME (IDSPACE:ACCESSION)
- No entity exists with the same term
- The term already exists (separate message for missing ID Space vs. Accession)

✅ The term is added to the entity during the submit
✅ The content type listing is updated to display the term
✅ Fixed bug in the entity where it set the ID Space in setTermAccession() instead of the accession
✅ Fixed a bug where you couldn't save an existing content type because it tried to re-assign the id.