### PR TITLE
Docker Build: Do not run composer as superuser error

### DIFF
--- a/tripaldocker/Dockerfile-php8-pgsql13
+++ b/tripaldocker/Dockerfile-php8-pgsql13
@@ -73,58 +73,58 @@ RUN pecl install xdebug-3.1.5 \
 
 ## install the PHP extensions we need
 RUN set -eux; \
-	\
-	if command -v a2enmod; then \
-		a2enmod rewrite; \
-	fi; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	\
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		libfreetype6-dev \
-		libjpeg-dev \
-		libpng-dev \
+  \
+  if command -v a2enmod; then \
+    a2enmod rewrite; \
+  fi; \
+  \
+  savedAptMark="$(apt-mark showmanual)"; \
+  \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    libfreetype6-dev \
+    libjpeg-dev \
+    libpng-dev \
     libwebp-dev \
-		libpq-dev \
-		libzip-dev \
-	; \
-	\
-	docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp; \
-	\
-	docker-php-ext-install -j "$(nproc)" \
-		gd \
-		opcache \
-		pdo_mysql \
-		pdo_pgsql \
+    libpq-dev \
+    libzip-dev \
+  ; \
+  \
+  docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp; \
+  \
+  docker-php-ext-install -j "$(nproc)" \
+    gd \
+    opcache \
+    pdo_mysql \
+    pdo_pgsql \
     pgsql \
-		zip \
-	; \
-	\
+    zip \
+  ; \
+  \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-		| awk '/=>/ { print $3 }' \
-		| sort -u \
-		| xargs -r dpkg-query -S \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -rt apt-mark manual; \
-	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+  apt-mark auto '.*' > /dev/null; \
+  apt-mark manual $savedAptMark; \
+  ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+    | awk '/=>/ { print $3 }' \
+    | sort -u \
+    | xargs -r dpkg-query -S \
+    | cut -d: -f1 \
+    | sort -u \
+    | xargs -rt apt-mark manual; \
+  \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+  rm -rf /var/lib/apt/lists/*
 
 ## set recommended PHP.ini settings
 ## see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
-		echo 'opcache.memory_consumption=128'; \
-		echo 'opcache.interned_strings_buffer=8'; \
-		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=60'; \
+    echo 'opcache.fast_shutdown=1'; \
     echo 'opcache.memory_limit=1028M';\
-	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+  } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
@@ -141,6 +141,9 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 ENV SIMPLETEST_BASE_URL=http://localhost
 ENV SIMPLETEST_DB=pgsql://drupaladmin:drupal9developmentonlylocal@localhost/sitedb
 ENV BROWSER_OUTPUT_DIRECTORY=/var/www/drupal9/web/sites/default/files/simpletest
+ENV COMPOSER_MEMORY_LIMIT=-1
+ENV COMPOSER_NO_INTERACTION=1
+ENV COMPOSER_ALLOW_SUPERUSER=1
 
 ## Install composer and Drush.
 WORKDIR /var/www
@@ -152,8 +155,7 @@ RUN chmod a+x /app/tripaldocker/init_scripts/composer-init.sh \
 WORKDIR /var/www
 ARG requiredcomposerpackages="drupal/core:${drupalversion} drupal/core-dev:${drupalversion} drush/drush phpspec/prophecy-phpunit"
 ARG composerpackages="drupal/devel drupal/devel_php"
-RUN export COMPOSER_MEMORY_LIMIT=-1 && export COMPOSER_NO_INTERACTION=1 \
-  && composer create-project drupal/recommended-project:${drupalversion} --stability dev --no-install drupal9 \
+RUN composer create-project drupal/recommended-project:${drupalversion} --stability dev --no-install drupal9 \
   && cd drupal9 \
   && composer config --no-plugins allow-plugins.composer/installers true \
   && composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true \

--- a/tripaldocker/Dockerfile-php8.1-pgsql13
+++ b/tripaldocker/Dockerfile-php8.1-pgsql13
@@ -73,58 +73,58 @@ RUN pecl install xdebug-3.1.5 \
 
 ## install the PHP extensions we need
 RUN set -eux; \
-	\
-	if command -v a2enmod; then \
-		a2enmod rewrite; \
-	fi; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	\
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		libfreetype6-dev \
-		libjpeg-dev \
-		libpng-dev \
+  \
+  if command -v a2enmod; then \
+    a2enmod rewrite; \
+  fi; \
+  \
+  savedAptMark="$(apt-mark showmanual)"; \
+  \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    libfreetype6-dev \
+    libjpeg-dev \
+    libpng-dev \
     libwebp-dev \
-		libpq-dev \
-		libzip-dev \
-	; \
-	\
-	docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp; \
-	\
-	docker-php-ext-install -j "$(nproc)" \
-		gd \
-		opcache \
-		pdo_mysql \
-		pdo_pgsql \
+    libpq-dev \
+    libzip-dev \
+  ; \
+  \
+  docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp; \
+  \
+  docker-php-ext-install -j "$(nproc)" \
+    gd \
+    opcache \
+    pdo_mysql \
+    pdo_pgsql \
     pgsql \
-		zip \
-	; \
-	\
+    zip \
+  ; \
+  \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark; \
-	ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-		| awk '/=>/ { print $3 }' \
-		| sort -u \
-		| xargs -r dpkg-query -S \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -rt apt-mark manual; \
-	\
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	rm -rf /var/lib/apt/lists/*
+  apt-mark auto '.*' > /dev/null; \
+  apt-mark manual $savedAptMark; \
+  ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+    | awk '/=>/ { print $3 }' \
+    | sort -u \
+    | xargs -r dpkg-query -S \
+    | cut -d: -f1 \
+    | sort -u \
+    | xargs -rt apt-mark manual; \
+  \
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+  rm -rf /var/lib/apt/lists/*
 
 ## set recommended PHP.ini settings
 ## see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
-		echo 'opcache.memory_consumption=128'; \
-		echo 'opcache.interned_strings_buffer=8'; \
-		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
+    echo 'opcache.memory_consumption=128'; \
+    echo 'opcache.interned_strings_buffer=8'; \
+    echo 'opcache.max_accelerated_files=4000'; \
+    echo 'opcache.revalidate_freq=60'; \
+    echo 'opcache.fast_shutdown=1'; \
     echo 'opcache.memory_limit=1028M';\
-	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+  } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 RUN echo 'memory_limit = 1028M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 
@@ -141,6 +141,9 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 ENV SIMPLETEST_BASE_URL=http://localhost
 ENV SIMPLETEST_DB=pgsql://drupaladmin:drupal9developmentonlylocal@localhost/sitedb
 ENV BROWSER_OUTPUT_DIRECTORY=/var/www/drupal9/web/sites/default/files/simpletest
+ENV COMPOSER_MEMORY_LIMIT=-1
+ENV COMPOSER_NO_INTERACTION=1
+ENV COMPOSER_ALLOW_SUPERUSER=1
 
 ## Install composer and Drush.
 WORKDIR /var/www
@@ -152,8 +155,7 @@ RUN chmod a+x /app/tripaldocker/init_scripts/composer-init.sh \
 WORKDIR /var/www
 ARG requiredcomposerpackages="drupal/core:${drupalversion} drupal/core-dev:${drupalversion} drush/drush phpspec/prophecy-phpunit"
 ARG composerpackages="drupal/devel drupal/devel_php"
-RUN export COMPOSER_MEMORY_LIMIT=-1 && export COMPOSER_NO_INTERACTION=1 \
-  && composer create-project drupal/recommended-project:${drupalversion} --stability dev --no-install drupal9 \
+RUN composer create-project drupal/recommended-project:${drupalversion} --stability dev --no-install drupal9 \
   && cd drupal9 \
   && composer config --no-plugins allow-plugins.composer/installers true \
   && composer config --no-plugins allow-plugins.drupal/core-composer-scaffold true \


### PR DESCRIPTION
Issue tripal/tripal#1372 

tl;dr
When building the current docker, the newest version of composer now puts out an error which halts image creation.

## Testing
Not needed since automated testing requires that the docker image can be built in all our test environments.