### PR TITLE
Remove auto-creation of Chado in Tests

### DIFF
--- a/tripal_chado/tests/src/Functional/ChadoCustomTables/ChadoCustomTableTest.php
+++ b/tripal_chado/tests/src/Functional/ChadoCustomTables/ChadoCustomTableTest.php
@@ -22,7 +22,7 @@ class ChadoCustomTablesTest extends ChadoTestBrowserBase {
     $manager = \Drupal::service('tripal_chado.custom_tables');
     $this->assertIsObject($manager, 'Able to retrieve the custom table service manager.');
 
-    $chado = $this->getTestSchema();
+    $chado = $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
     $chado_schema_name = $chado->getSchemaName();
 
     // Test manager get list of chado custom tables.

--- a/tripal_chado/tests/src/Functional/ChadoCustomTables/ChadoCustomTableTest.php
+++ b/tripal_chado/tests/src/Functional/ChadoCustomTables/ChadoCustomTableTest.php
@@ -22,7 +22,8 @@ class ChadoCustomTablesTest extends ChadoTestBrowserBase {
     $manager = \Drupal::service('tripal_chado.custom_tables');
     $this->assertIsObject($manager, 'Able to retrieve the custom table service manager.');
 
-    $chado_schema_name = $this->chado->getSchemaName();
+    $chado = $this->getTestSchema();
+    $chado_schema_name = $chado->getSchemaName();
 
     // Test manager get list of chado custom tables.
     $custom_tables = $manager->getTables($chado_schema_name);

--- a/tripal_chado/tests/src/Functional/ChadoTestBrowserBase.php
+++ b/tripal_chado/tests/src/Functional/ChadoTestBrowserBase.php
@@ -59,11 +59,6 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
   public const PREPARE_TEST_CHADO = 5;
 
   /**
-   * ChadoConnection instance
-   */
-  protected $chado = NULL;
-
-  /**
    * {@inheritdoc}
    */
   protected static $modules = ['tripal', 'tripal_biodb', 'tripal_chado'];
@@ -81,8 +76,6 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
       $this->getRealConfig();
       $this->initTripalDbx();
       $this->allowTestSchemas();
-
-      $this->chado = $this->getTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
     }
   }
 
@@ -103,6 +96,8 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
    *   The organism entity.
    */
   protected function createTestOrganismEntity($genus, $species) {
+
+    $chado = $this->getTestSchema();
 
     // Create the Organism Content Type
     $this->createTripalContentType([
@@ -317,7 +312,7 @@ abstract class ChadoTestBrowserBase extends TripalTestBrowserBase {
     $entity->save();
 
     // Make sure there is a record in the Chado database
-    $query = $this->chado->select('1:organism', 'O');
+    $query = $chado->select('1:organism', 'O');
     $query->fields('O', ['organism_id']);
     $query->condition('genus', $genus);
     $query->condition('species', $species);

--- a/tripal_chado/tests/src/Functional/ChadoTestTrait.php
+++ b/tripal_chado/tests/src/Functional/ChadoTestTrait.php
@@ -48,6 +48,11 @@ trait ChadoTestTrait  {
   protected static $testSchemas = [];
 
   /**
+   * A string indicating the name of the current chado test schema.
+   */
+  protected $testSchemaName = NULL;
+
+  /**
    * A database connection.
    *
    * It should be set if not set in any test function that adds schema names to
@@ -199,6 +204,32 @@ trait ChadoTestTrait  {
 
   /**
    * Gets a new Chado schema for testing.
+   * Retrieves the current test schema.
+   * If there is not currently a test schema set-up then one will be created.
+   *
+   * @param int $init_level
+   *   One of the constant to select the schema initialization level.
+   *   If this is supplied then it forces a new connection to be made for
+   *   backwards compatibility.
+   *
+   * @return \Drupal\tripal\TripalDBX\TripalDbxConnection
+   *   A bio database connection using the generated schema.
+   */
+  protected function getTestSchema(int $init_level = NULL) {
+
+    if ($init_level !== NULL) {
+      return $this->createTestSchema($init_level);
+    }
+    elseif ($this->testSchemaName === NULL) {
+      return $this->createTestSchema();
+    }
+    else {
+      return new ChadoConnection($this->testSchemaName);
+    }
+  }
+
+  /**
+   * Creates a new Chado schema for testing.
    *
    * @param int $init_level
    *   One of the constant to select the schema initialization level.
@@ -206,7 +237,7 @@ trait ChadoTestTrait  {
    * @return \Drupal\tripal\TripalDBX\TripalDbxConnection
    *   A bio database connection using the generated schema.
    */
-  protected function getTestSchema(int $init_level = 0) {
+  protected function createTestSchema(int $init_level = 0) {
     $schema_name = $this->testSchemaBaseNames['chado']
       . '_'
       . bin2hex(random_bytes(8))
@@ -291,6 +322,7 @@ trait ChadoTestTrait  {
     }
     self::$db = self::$db ?? \Drupal::database();
     self::$testSchemas[$schema_name] = TRUE;
+    $this->testSchemaName = $schema_name;
 
     // Make sure that any other connections to TripalDBX will see this new test schema as
     // the default schema.

--- a/tripal_chado/tests/src/Functional/Database/ChadoConnectionTest.php
+++ b/tripal_chado/tests/src/Functional/Database/ChadoConnectionTest.php
@@ -36,6 +36,7 @@ class ChadoConnectionTest extends ChadoTestBrowserBase {
    * the Drupal testing is sufficient for the query builders.
    */
   public function testDefaultTablePrefixing() {
+    $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
 
     // Open a Connection to the default Tripal DBX managed Chado schema.
     $connection = \Drupal::service('tripal_chado.database');
@@ -114,21 +115,22 @@ class ChadoConnectionTest extends ChadoTestBrowserBase {
    * Tests the Drupal query builders while quering chado.
    */
   public function testChadoQueryBuilding() {
+    $chado = $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
 
     // INSERT:
     try {
-      $query = $this->chado->insert('1:db')
+      $query = $chado->insert('1:db')
         ->fields(['name' => 'GO']);
       $query->execute();
     } catch (\Drupal\Core\Database\DatabaseExceptionWrapper $e) {
       $this->assertTrue(FALSE, "We should be able to insert into the Chado db table.");
     }
-    $db_id = $this->chado->query("SELECT db_id FROM {1:db} WHERE name='GO'")->fetchField();
+    $db_id = $chado->query("SELECT db_id FROM {1:db} WHERE name='GO'")->fetchField();
     $this->assertIsNumeric($db_id, "We should be able to select the primary key of the newly inserted db record.");
 
     // SELECT:
     try {
-      $queryBuilder_db_id = $this->chado->select('1:db', 'db')
+      $queryBuilder_db_id = $chado->select('1:db', 'db')
         ->fields('db', ['db_id'])
         ->condition('db.name', 'GO', '=')
         ->execute()
@@ -142,27 +144,27 @@ class ChadoConnectionTest extends ChadoTestBrowserBase {
     // UPDATE:
     $description = 'This is the description we will add during update.';
     try {
-      $query = $this->chado->update('1:db')
+      $query = $chado->update('1:db')
         ->fields(['description' => $description])
         ->condition('name', 'GO', '=');
       $query->execute();
     } catch (\Drupal\Core\Database\DatabaseExceptionWrapper $e) {
       $this->assertTrue(FALSE, "We should be able to update the Chado db table using the query builder.");
     }
-    $results = $this->chado->query("SELECT * FROM {1:db} WHERE name='GO'")->fetchAll();
+    $results = $chado->query("SELECT * FROM {1:db} WHERE name='GO'")->fetchAll();
     $this->assertEquals(1, sizeof($results), "There should be only a single GO db record.");
     $this->assertIsNumeric($results[0]->db_id, "We should be able to select the primary key of the newly updated db record.");
     $this->assertEquals($db_id, $results[0]->db_id, "The primary key should remain unchanged during update.");
 
     // DELETE:
     try {
-      $this->chado->delete('1:db')
+      $chado->delete('1:db')
         ->condition('db.name', 'GO', '=')
         ->execute();
     } catch (\Drupal\Core\Database\DatabaseExceptionWrapper $e) {
       $this->assertTrue(FALSE, "We should be able to delete from the Chado db table using the query builder.");
     }
-    $results = $this->chado->query("SELECT * FROM {1:db} WHERE name='GO'")->fetchAll();
+    $results = $chado->query("SELECT * FROM {1:db} WHERE name='GO'")->fetchAll();
     $this->assertEquals(0, sizeof($results), "There should not be any GO db record left.");
 
   }
@@ -185,7 +187,7 @@ class ChadoConnectionTest extends ChadoTestBrowserBase {
     $expected_version = '1.3';
 
     // Test 1A
-    $connection = $this->chado;
+    $connection = $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
     $version = $connection->findVersion();
     $this->assertEquals($version, $expected_version,
       "Unable to extract the version from INIT_CHADO_EMPTY test schema with no parameters provided.");
@@ -201,7 +203,7 @@ class ChadoConnectionTest extends ChadoTestBrowserBase {
       "Unable to extract the Exact Version from INIT_CHADO_EMPTY test schema with the schema name provided.");
 
     // Test 2A
-    $connection = $this->getTestSchema(ChadoTestBrowserBase::INIT_CHADO_DUMMY);
+    $connection = $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_DUMMY);
     $version = $connection->findVersion();
     $this->assertEquals($version, $expected_version,
       "Unable to extract the version from INIT_CHADO_DUMMY test schema with no parameters provided.");
@@ -217,7 +219,7 @@ class ChadoConnectionTest extends ChadoTestBrowserBase {
       "Unable to extract the Exact Version from INIT_CHADO_DUMMY test schema with the schema name provided.");
 
     // Test 3A
-    $connection = $this->getTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
+    $connection = $this->createTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
     $version = $connection->findVersion();
     $this->assertEquals($version, $expected_version,
       "Unable to extract the version from PREPARE_TEST_CHADO test schema with no parameters provided.");

--- a/tripal_chado/tests/src/Functional/Plugin/ChadoStorageTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/ChadoStorageTest.php
@@ -30,6 +30,11 @@ class ChadoStorageTest extends ChadoTestBrowserBase {
    *
    */
   public function testChadoStorage() {
+
+    // Create a new test schema for us to use.
+    $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
+
+    // Get plugin managers we need for our testing.
     $storage_manager = \Drupal::service('tripal.storage');
     $chado_storage = $storage_manager->createInstance('chado_storage');
 
@@ -376,7 +381,10 @@ class ChadoStorageTest extends ChadoTestBrowserBase {
    */
   protected function addOryzaSativaRecord($type_term) {
 
-    $this->chado->insert('1:organism')
+    // Retrieve the test schema created in testChadoStorage().
+    $chado = $this->getTestSchema();
+
+    $chado->insert('1:organism')
       ->fields([
         'genus' => 'Oryza',
         'species' => 'sativa',
@@ -388,7 +396,7 @@ class ChadoStorageTest extends ChadoTestBrowserBase {
       ])
       ->execute();
 
-    return $this->chado->select('1:organism', 'O')
+    return $chado->select('1:organism', 'O')
       ->fields('O')
       ->condition('species', 'sativa')
       ->execute()
@@ -420,7 +428,10 @@ class ChadoStorageTest extends ChadoTestBrowserBase {
    */
   protected function addFeatureRecord($name, $uniquename, $type, $organism) {
 
-    $this->chado->insert('1:feature')
+    // Retrieve the test schema created in testChadoStorage().
+    $chado = $this->getTestSchema();
+
+    $chado->insert('1:feature')
       ->fields([
         'name' => $name,
         'uniquename' => $uniquename,
@@ -429,7 +440,7 @@ class ChadoStorageTest extends ChadoTestBrowserBase {
       ])
       ->execute();
 
-    return $this->chado->select('1:feature', 'F')
+    return $chado->select('1:feature', 'F')
       ->fields('F')
       ->condition('name', $name)
       ->execute()
@@ -440,7 +451,11 @@ class ChadoStorageTest extends ChadoTestBrowserBase {
    * A helper function for adding notes values to the featureprop table.
    */
   protected function addFeaturePropRecords($feature, $term, $value, $rank) {
-    $this->chado->insert('1:featureprop')
+
+    // Retrieve the test schema created in testChadoStorage().
+    $chado = $this->getTestSchema();
+
+    $chado->insert('1:featureprop')
       ->fields([
         'feature_id' => $feature->feature_id,
         'type_id' => $term->getInternalId(),

--- a/tripal_chado/tests/src/Functional/Plugin/ChadoVocabTermsTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/ChadoVocabTermsTest.php
@@ -27,7 +27,10 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
    */
   protected function getCV($cvname) {
 
-    $query = $this->chado->select('1:cv', 'cv')
+    // Retrieve the test schema created in testTripalVocabularyClasses().
+    $chado = $this->getTestSchema();
+
+    $query = $chado->select('1:cv', 'cv')
       ->condition('cv.name', $cvname, '=')
       ->fields('cv', ['name', 'definition']);
     $result = $query->execute();
@@ -47,7 +50,10 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
    */
   protected function getDB($dbname) {
 
-    $query = $this->chado->select('1:db', 'db')
+    // Retrieve the test schema created in testTripalVocabularyClasses().
+    $chado = $this->getTestSchema();
+
+    $query = $chado->select('1:db', 'db')
       ->condition('db.name', $dbname, '=')
       ->fields('db', ['name', 'urlprefix', 'url', 'description']);
     $result = $query->execute();
@@ -64,7 +70,11 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
    * @param string $cvterm_name
    */
   protected function getCVterm($cvname, $cvterm_name) {
-    $query = $this->chado->select('1:cvterm', 'CVT');
+
+    // Retrieve the test schema created in testTripalVocabularyClasses().
+    $chado = $this->getTestSchema();
+
+    $query = $chado->select('1:cvterm', 'CVT');
     $query->join('1:cv', 'CV', '"CV".cv_id = "CVT".cv_id');
     $query->fields('CVT', ['cv_id', 'name', 'cvterm_id', 'definition', 'is_obsolete', 'is_relationshiptype'])
       ->condition('CVT.name', $cvterm_name, '=')
@@ -85,7 +95,11 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
    * @return A database query result.
    */
   protected function updateRecord($table, $name, $field, $value) {
-    $query = $this->chado->update('1:' . $table)
+
+    // Retrieve the test schema created in testTripalVocabularyClasses().
+    $chado = $this->getTestSchema();
+
+    $query = $chado->update('1:' . $table)
       ->condition('name', $name, '=')
       ->fields([$field => $value]);
     return $query->execute();
@@ -100,7 +114,11 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
    * @return The number of records deleted.
    */
   protected function cleanDB($dbname) {
-    $query = $this->chado->delete('1:db')
+
+    // Retrieve the test schema created in testTripalVocabularyClasses().
+    $chado = $this->getTestSchema();
+
+    $query = $chado->delete('1:db')
       ->condition('name', $dbname, '=');
     return $query->execute();
   }
@@ -114,7 +132,11 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
    * @return The number of records deleted.
    */
   protected function cleanCV($cvname) {
-    $query = $this->chado->delete('1:cv', 'cv')
+
+    // Retrieve the test schema created in testTripalVocabularyClasses().
+    $chado = $this->getTestSchema();
+
+    $query = $chado->delete('1:cv', 'cv')
       ->condition('name', $cvname, '=');
     return $query->execute();
   }
@@ -126,6 +148,9 @@ class ChadoVocabTermsTest extends ChadoTestBrowserBase {
    *
    */
   public function testTripalVocabularyClasses() {
+
+    // Create a new test schema for us to use.
+    $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
 
     // Create Collection managers.
     $idsmanager = \Drupal::service('tripal.collection_plugin_manager.idspace');

--- a/tripal_chado/tests/src/Functional/Plugin/OBOImporterTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/OBOImporterTest.php
@@ -30,7 +30,7 @@ class OBOImporterTest extends ChadoTestBrowserBase {
     );
 
     $public = \Drupal::database();
-    $test_chado = $this->chado;
+    $test_chado = $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
 
     // Insert a record into the tripal_cv_obo table for a vocabulary to load.
     $insert = $public->insert('tripal_cv_obo');

--- a/tripal_chado/tests/src/Functional/Plugin/TripalField_chado_linker__propTest.php
+++ b/tripal_chado/tests/src/Functional/Plugin/TripalField_chado_linker__propTest.php
@@ -30,7 +30,7 @@ class TripalField_chado_linker__propTest extends ChadoTestBrowserBase {
     parent::setup();
 
     // Use the Preapred test chado schema.
-    $this->getTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
+    $this->createTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);
 
   }
 

--- a/tripal_chado/tests/src/Functional/Task/ChadoPreparerTest.php
+++ b/tripal_chado/tests/src/Functional/Task/ChadoPreparerTest.php
@@ -27,7 +27,7 @@ class ChadoPreparerTest extends ChadoTestBrowserBase {
    */
   public function testChadoPreparer() {
 
-    $test_chado = $this->chado;
+    $test_chado = $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
 
     // Sanity check: make sure we have the necessary tables.
     $public = \Drupal::database();

--- a/tripal_chado/tests/src/Functional/api/ChadoCvAPITest.php
+++ b/tripal_chado/tests/src/Functional/api/ChadoCvAPITest.php
@@ -30,9 +30,10 @@ class ChadoCvAPITest extends ChadoTestBrowserBase {
 
     parent::setUp();
 
-    $this->assertIsObject($this->chado, "Chado test schema was not set-up properly.");
+    $chado = $this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);
+    $this->assertIsObject($chado, "Chado test schema was not set-up properly.");
 
-    $schema_name = $this->chado->getSchemaName();
+    $schema_name = $chado->getSchemaName();
     $this->assertNotEmpty($schema_name, "We were not able to retrieve the schema name.");
 
     $this->schema_name = $schema_name;


### PR DESCRIPTION
It ended up being a bit more complicated because we need the connection information in helper functions and passing a connection variable in tests causes errors.

As such we now have a `ChadoTestTrait->createTestSchema()` and `ChadoTestTrait->getTestSchema()`. You use the create when you want to create a new test schema. This should happen at the beginning of all tests. It is not done in the ChadoTestBrowserBase though because people need to set the init level they want. In most cases you should use either of the following either in the setup in your test or as the first line in the test method.

1. `$this->createTestSchema(ChadoTestBrowserBase::INIT_CHADO_EMPTY);`
2. `$this->createTestSchema(ChadoTestBrowserBase::PREPARE_TEST_CHADO);`

Then in the helper function you use:

`$chado = $this->getTestSchema();`

## What is this doing / How does this work?

When you use createTestSchema, it creates a new schema and populates it based on the init level you passed in. It also adds the schema name to an array of test schema to drop later. This is what used to happen too... What's different is that now it also assigns the schema name to `$this->testSchemaName` which is a single string for the current test schema being used.

Then when you call getTestSchema it creates a new ChadoConnection pointing at `$this->testSchemaName` and thus gives you access to the current test schema -whatever it may be.

NOTE: Even if you are not using the chado connection directly in your test, you still want to call createTestSchema. This method also sets the default chado schema to be the current test schema. Most places in Tripal will use the default chado schema unless it is otherwise specified and thus the test schema is used.