### PR TITLE
Fix issue #324 by removing old drush depenendancy.

### DIFF
--- a/tripaldocker/Dockerfile-php8-pgsql13
+++ b/tripaldocker/Dockerfile-php8-pgsql13
@@ -148,8 +148,7 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 ## Install composer and Drush.
 WORKDIR /var/www
 RUN chmod a+x /app/tripaldocker/init_scripts/composer-init.sh \
-  && /app/tripaldocker/init_scripts/composer-init.sh \
-  && vendor/bin/drush --version
+  && /app/tripaldocker/init_scripts/composer-init.sh
 
 ## Use composer to install Drupal.
 WORKDIR /var/www

--- a/tripaldocker/Dockerfile-php8.1-pgsql13
+++ b/tripaldocker/Dockerfile-php8.1-pgsql13
@@ -148,8 +148,7 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 ## Install composer and Drush.
 WORKDIR /var/www
 RUN chmod a+x /app/tripaldocker/init_scripts/composer-init.sh \
-  && /app/tripaldocker/init_scripts/composer-init.sh \
-  && vendor/bin/drush --version
+  && /app/tripaldocker/init_scripts/composer-init.sh
 
 ## Use composer to install Drupal.
 WORKDIR /var/www

--- a/tripaldocker/init_scripts/composer-init.sh
+++ b/tripaldocker/init_scripts/composer-init.sh
@@ -13,4 +13,3 @@ fi
 
 php -d memory_limit=-1 composer-setup.php --quiet
 mv composer.phar /usr/local/bin/composer
-composer --quiet require drush/drush:8.*


### PR DESCRIPTION
Yesterday @spficklin mentioned that tripaldocker was failing to build locally for him sometimes and then last night it happened to me as well. My error was due to composer failing to resolve dependancies.

This PR removes an old drush dependency from tripaldocker which was added when installing composer. Specifically,

```
composer --quiet require drush/drush:8.*
```

Drush is still installed via the Dockerfile but does not have the version indicated. This allows composer to make the right decisions about dependencies.

## Testing

No testing required as the automated tests will build the docker with all versions of Drupal indicated and using PHP 8.0 and 8.1 so this should test all combinations of dependency resolving that composer needs to worry about.